### PR TITLE
refactor(governance): remove redundancies and standardize tool pathing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Commit and PR titles follow [Conventional Commits](https://www.conventionalcommi
 
 ## [Unreleased]
 
+### Refactored
+- `instructions/`: Consolidated `operator-identity-context` / `role-baton` duplication, centralized docs drift to `release-docs-hygiene`, shifted OpenSSF security rules to `github-governance`, fixed legacy `.copilot` paths, and softened dangling specialist skill references.
+
 ### Added
 - `sync/create-pr.sh` — AI-invocable script to propose a self-annealed improvement as a draft GitHub PR for user review before any change propagates to other machines
 - `sync/pull.sh` — `--ff-only` pull from `origin/main`, run by systemd user timer every 15 minutes

--- a/instructions/github-governance.instructions.md
+++ b/instructions/github-governance.instructions.md
@@ -25,7 +25,7 @@ applyTo: "**"
 - Issues must include: problem/objective, expected outcome, acceptance criteria.
 - Large work is decomposed with sub-issues and `blocked by` / `blocking` dependencies.
 - Templates required: at minimum bug, task, and epic forms. `blank_issues_enabled: false` in config.yml.
-- For detailed lifecycle execution, invoke `github-ticket-lifecycle-orchestrator` skill.
+- For detailed lifecycle execution, if available, invoke the `github-ticket-lifecycle-orchestrator` skill.
 
 ## Review and merge gates
 
@@ -34,15 +34,18 @@ applyTo: "**"
 - All review conversations resolved.
 - Rulesets/branch protection requirements satisfied.
 - Merge method follows repo policy.
-- For detailed review/merge administration, invoke `github-review-merge-admin` skill.
+- For detailed review/merge administration, if available, invoke the `github-review-merge-admin` skill.
 
-## Actions security baseline
+## Actions & OpenSSF security baseline
 
-- `GITHUB_TOKEN`: default to read permissions; elevate per-job only when required.
-- Third-party actions: pin to full commit SHA where policy requires.
+- `GITHUB_TOKEN`: default to read-all permissions; grant write only per-job when required.
+- Third-party actions: pin to full commit SHA, not tags.
 - Prefer OIDC over long-lived static cloud credentials.
 - CODEOWNERS coverage for `.github/workflows/`.
 - No auto-remediation that broadens permissions.
+- Enable Dependabot alerts, secret scanning, and push protection on every public repo.
+- Add `ossf/scorecard-action` to CI for public repos to track security posture.
+- Private vulnerability reporting enabled via GitHub settings.
 - For detailed Actions hardening, invoke `github-actions-security-hardening` skill.
 
 ## Release and incident flow
@@ -53,18 +56,18 @@ applyTo: "**"
 - Incident items include severity, impact, owner, and containment plan.
 - Hotfix branch/PR linked to incident issue with validation evidence.
 - Follow-up prevention tickets created before incident closure.
-- For detailed release/incident procedures, invoke `github-release-incident-flow` skill.
+- For detailed release/incident procedures, if available, invoke the `github-release-incident-flow` skill.
 
 ## Project linkage
 
 - Project items have status, priority, iteration, and owner fields populated.
 - Issue ↔ branch and issue ↔ PR linkage maintained in the Development panel.
 - Built-in workflows: auto-add, status sync, auto-archive configured where available.
-- For detailed Agile linkage setup, invoke `github-projects-agile-linkage` skill.
+- For detailed Agile linkage setup, if available, invoke the `github-projects-agile-linkage` skill.
 
 ## Capability-first routing
 
 - Before recommending rulesets, merge queue, or plan-sensitive features, run `github-capability-resolver` to verify availability by plan/visibility/owner type.
-- Route all GitHub workflow governance requests through `github-ops-tree-router` to the correct specialist skill.
+- If available, route GitHub workflow governance requests through `github-ops-tree-router`.
 - Use `github-ops-excellence` as the policy catalog overlay for calibrating strictness.
 - For ruleset design/migration, invoke `github-ruleset-architecture` skill.

--- a/instructions/global-standards.instructions.md
+++ b/instructions/global-standards.instructions.md
@@ -10,7 +10,6 @@ applyTo: "**"
 - Never claim build, test, release, or publish success without explicit evidence.
 - Keep changes minimal, localized, and reversible.
 - Preserve public APIs unless change scope explicitly requires API updates.
-- When behavior or interfaces change, update documentation in the same change.
 - Never expose secrets in repository files, packaged artifacts, logs, or generated examples.
 - Before packaging/publishing, verify exclude rules (`.vscodeignore`, `.npmignore`, artifact manifests) block secret-bearing files. Run manifest listing commands (`vsce ls`, `npm pack --dry-run`) as preflight.
 - Use placeholders in docs and examples — never live tokens, keys, or credentials.

--- a/instructions/operator-identity-context.instructions.md
+++ b/instructions/operator-identity-context.instructions.md
@@ -10,12 +10,7 @@ Load and apply the `operator-identity-context` skill at the start of every task.
 
 ## Core rules (always active)
 
-1. **You are the operator.** You own manager, collaborator, admin, and consultant responsibilities, but execute them in a **single-thread baton sequence**:
-   - Manager (scope + plan + gates)
-   - Collaborator (implement + validate)
-   - Admin (git/release/runtime ops)
-   - Consultant (independent critique and risk review)
-   At most one role is active at a time.
+1. **You are the operator.** You own manager, collaborator, admin, and consultant responsibilities. State management and single-thread execution routing are exclusively governed by the `role-baton-routing` instructions.
 
 2. **The user is the client.** Curtis / Hayden is consulted only for:
    - Design direction (colors, layout, copy preferences)

--- a/instructions/playwright-mcp-low-resource.instructions.md
+++ b/instructions/playwright-mcp-low-resource.instructions.md
@@ -8,7 +8,7 @@ When the task involves Playwright MCP, browser automation, visual QA, screenshot
 
 1. Apply the `playwright-vision-low-resource` skill first.
 2. Run preflight before browser actions:
-   - `~/.copilot/skills/playwright-vision-low-resource/scripts/preflight-playwright-mcp.sh`
+   - `~/.gemini/antigravity/skills/playwright-vision-low-resource/scripts/preflight-playwright-mcp.sh`
 3. Use bounded retries:
    - Maximum 2 retries for browser-context failures.
 4. Prefer local constrained profile by default:

--- a/instructions/release-docs-hygiene.instructions.md
+++ b/instructions/release-docs-hygiene.instructions.md
@@ -8,7 +8,10 @@ applyTo: "**"
 - Before any release action, verify version consistency between tag, manifest, and changelog. Invoke `release-version-integrity` skill for systematic drift detection.
 - Audit packaged artifact file lists before publish when packaging tools support manifest listing.
 - Treat `.env`, key material, token files, and private config as non-distributable by default. Invoke `secret-exposure-prevention` skill when editing publish/package workflows.
-- If commands, configuration, workflows, or user-facing behavior change, update README/CHANGELOG and operation docs. Invoke `docs-drift-maintenance` skill to systematically detect stale documentation.
+- Run `docs-drift-maintenance` skill after any change to commands, CLI flags, configuration files, APIs, workflows, or user-facing behavior.
+- Docs updates must ship with changes — not as follow-up.
+- Map each changed surface to impacted docs (README, CHANGELOG, operational docs, runbooks).
+- Keep wording precise, testable, and user-actionable. Verify docs match actual behavior after updates.
 - Prefer automated versioning flows over manual multi-file version edits.
 - Keep release notes factual and traceable to merged changes.
 

--- a/instructions/repo-health-onboarding.instructions.md
+++ b/instructions/repo-health-onboarding.instructions.md
@@ -39,32 +39,25 @@ Files live in repo root or `.github/`. Missing items are prioritized:
 - Classify repository by primary app type (`website-static`, `web-app`, `library-sdk`, `infra-automation`) before applying standards.
 - Apply core-baseline controls, then primary-type controls, then relevant overlays (`security`, `collaboration`, `release`, `observability`).
 - Prefer the smallest correct standards stack over over-engineered policy.
-- For detailed routing, invoke `repo-standards-router` skill.
+- For detailed routing, if available, invoke `repo-standards-router` skill.
 - For new/uninitialized repos, invoke `repo-onboarding-standards` skill.
 
 ## Governance audit triggers
 
 Run `repo-profile-governance` skill when:
 - Starting a new session in any repository (quick health check).
-- After a PR merge or deployment that changes user-facing behavior.
 - Before any public release.
 - When community health gaps are suspected.
 
 ## Repository structure conventions
 
-- On new repos or restructuring, invoke `repo-structure-conventions` skill.
+- On new repos or restructuring, if available, invoke `repo-structure-conventions` skill.
 - Every repo follows a universal root layout: README, LICENSE, CHANGELOG, .gitignore, .github/, docs/, scripts/, test/.
 - CHANGELOG.md follows [Keep a Changelog](https://keepachangelog.com/) format: Added, Changed, Deprecated, Removed, Fixed, Security.
 - Build artifacts are isolated via .gitignore (and .vscodeignore / .npmignore where applicable).
 - No build outputs (dist/, node_modules/, resources/, *.vsix, __pycache__/) in git history.
 
-## OpenSSF security alignment
 
-- Enable Dependabot alerts, secret scanning, and push protection on every public repo.
-- Add `ossf/scorecard-action` to CI for public repos to track security posture.
-- Pin third-party Actions to full commit SHA, not tags.
-- Workflow `permissions` block defaults to `read-all`; grant write only per-job.
-- Private vulnerability reporting enabled via GitHub settings.
 
 ## Consistency across repos
 

--- a/instructions/workflow-resilience.instructions.md
+++ b/instructions/workflow-resilience.instructions.md
@@ -32,19 +32,3 @@ Run `workflow-self-anneal` skill when any of these conditions is true:
 4. Propose minimal docs/workflow delta that prevents recurrence.
 5. Define objective verification gate confirming the fix works.
 
-## Documentation drift detection
-
-Run `docs-drift-maintenance` skill after any change to:
-- Commands, CLI flags, or API behavior.
-- Configuration files, defaults, or environment variables.
-- Workflows, CI/CD pipelines, or automation scripts.
-- UX-visible behavior, user-facing features, or settings.
-
-## Documentation drift rules
-
-- Docs updates must ship with behavior/config/workflow changes — not as follow-up.
-- Map each changed surface to impacted docs (README, CHANGELOG, operational docs, runbooks).
-- Identify stale, missing, or contradictory statements.
-- Keep wording precise, testable, and user-actionable.
-- Avoid speculative claims unsupported by current implementation.
-- Verify that docs match actual behavior and invocation paths after updates.


### PR DESCRIPTION
Consolidates and refactors redundant governance instructions regarding role routing, documentation drift, and GitHub Actions security. Updates legacy copilot application paths to gemini antigravity. Softens dangling skill references.