### PR TITLE
feat(#2064): end-to-end full baton-cycle fixture

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -64,6 +64,25 @@ jobs:
           fi
           echo "All instruction files non-empty."
 
+  validate-baton-e2e:
+    name: Baton full-cycle e2e fixture (#2064)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      # End-to-end fixture for the full Manager->Collaborator->Admin->Consultant
+      # baton cycle. Deterministic + offline (node built-ins only); exit 1 on any
+      # regression => red CI. No retries by design (see the spec's AC5 retry note).
+      # Requires the baton tooling dependency-closure to be present in the tree
+      # (baton-comment-build.js + baton-artifact-builder.js + baton-artifact-schema.js
+      # + baton-progression-parity.js + label-lint-close-protection.js + signer-alias).
+      - name: Run baton-e2e cycle fixture
+        run: node scripts/baton-e2e.spec.js
+
   validate-no-secrets:
     name: Check for accidental secret patterns
     runs-on: ubuntu-latest

--- a/scripts/asserted-vs-observed-probes.js
+++ b/scripts/asserted-vs-observed-probes.js
@@ -1,0 +1,143 @@
+'use strict';
+// asserted-vs-observed-probes — the F6 contradiction detector (Epic #3425 P1-c, the #3424 class).
+//
+// A baton artifact ASSERTS a state; a cheap read-only probe can falsify it. Each probe pairs an
+// assertion field with a comparator and, on mismatch, yields an F6 candidate tagged
+// confidence: high|medium|low. Design contract (research AC-R4):
+//   - cheap + bounded: per-probe budget (<=750ms), 3s total cap; over-budget => inconclusive.
+//   - squash-aware: the worktree probe uses CONTENT-equivalence (git cherry), not commit-reachability,
+//     so a squash-merged branch is treated as merged (never the #3424 false-positive).
+//   - confidence-gated: only HIGH-confidence (pure-local) probes are ever blocking-eligible; medium
+//     (network/gh) probes stay advisory permanently.
+//   - fail-open + observable: a probe that cannot run yields `inconclusive` + a probe_error row, never
+//     a false contradiction.
+//   - redacted: probe outputs pass through log-redaction before any emission.
+
+const { execFileSync } = require('child_process');
+const { redactString } = require('./log-redaction');
+
+const TOTAL_BUDGET_MS = 3000;
+const DEFAULT_PROBE_BUDGET_MS = 750; // per-probe ceiling (network probes)
+const LOCAL_PROBE_BUDGET_MS = 300;   // pure-local git probes (worktree list / cherry)
+const EXISTS_BUDGET_MS = 200;        // git cat-file existence check
+const F6_PATTERN_ID = 'asserted-vs-observed-contradiction';
+
+// Run a git/gh command read-only within a budget. Returns { ok, out } or { ok:false, reason }.
+function runCmd(cmd, args, opts = {}) {
+  try {
+    const out = execFileSync(cmd, args, { encoding: 'utf8', timeout: opts.budgetMs || DEFAULT_PROBE_BUDGET_MS,
+      stdio: ['ignore', 'pipe', 'ignore'], cwd: opts.cwd });
+    return { ok: true, out: String(out) };
+  } catch (err) {
+    const reason = err && err.code === 'ETIMEDOUT' ? 'timeout'
+      : (err && (err.code === 'ENOENT') ? 'tool-absent' : 'probe-error');
+    return { ok: false, reason };
+  }
+}
+
+// Read the artifact field value (line-anchored), or null when absent.
+function field(body, name) {
+  const match = String(body || '').match(new RegExp(`(?:^|\\n)[ \\t]*${name}[ \\t]*:[ \\t]*([^\\n]*)`, 'i'));
+  return match ? match[1].trim() : null;
+}
+
+// ---- SQUASH-AWARE worktree probe (HIGH confidence, pure-local) ----
+// A worktree branch is RESIDUAL only when it carries content not yet in main. `git cherry` marks a
+// commit `-` when an equivalent change is already in main (the squash/cherry-pick case) and `+` when
+// it is genuinely unmerged. Residual == any `+` line. This is the anti-#3424 core.
+function worktreeResidualBranches(mainRef, opts = {}) {
+  const list = runCmd('git', ['worktree', 'list', '--porcelain'], { budgetMs: LOCAL_PROBE_BUDGET_MS, cwd: opts.cwd });
+  if (!list.ok) return { inconclusive: true, reason: list.reason };
+  const branches = [...list.out.matchAll(/^branch\s+refs\/heads\/(.+)$/gim)].map((m) => m[1]);
+  const residual = [];
+  for (const branch of branches) {
+    if (branch === 'main' || branch === mainRef) continue;
+    const cherry = runCmd('git', ['cherry', mainRef, branch], { budgetMs: LOCAL_PROBE_BUDGET_MS, cwd: opts.cwd });
+    if (!cherry.ok) continue; // a branch we cannot compare is not asserted as residual (fail-open)
+    if (cherry.out.split('\n').some((line) => line.startsWith('+'))) residual.push(branch);
+  }
+  return { inconclusive: false, residual };
+}
+
+function worktreeProbe(body, ctx = {}) {
+  const value = field(body, 'worktree_residual_risk');
+  if (value === null || !/^(?:none|clean|this-ticket-clean)\b/i.test(value)) return null; // only probe a "clean" claim
+  const mainRef = ctx.mainRef || 'origin/main';
+  const result = worktreeResidualBranches(mainRef, ctx);
+  if (result.inconclusive) {
+    return { inconclusive: true, field: 'worktree_residual_risk', confidence: 'high', reason: result.reason };
+  }
+  if (result.residual.length === 0) return { contradiction: false, confidence: 'high' };
+  return { contradiction: true, confidence: 'high', field: 'worktree_residual_risk',
+    detail: `claims '${value}' but ${result.residual.length} worktree branch(es) carry unmerged content: ${result.residual.join(', ')}` };
+}
+
+// ---- existence probes (HIGH, pure-local) ----
+function commitProbe(body, ctx = {}) {
+  const value = field(body, 'commit');
+  if (!value || /n\/?a/i.test(value)) return null;
+  const sha = value.split(/\s/)[0];
+  const res = runCmd('git', ['cat-file', '-e', `${sha}^{commit}`], { budgetMs: EXISTS_BUDGET_MS, cwd: ctx.cwd });
+  if (res.ok) return { contradiction: false, confidence: 'high' };
+  if (res.reason === 'timeout' || res.reason === 'tool-absent') {
+    return { inconclusive: true, field: 'commit', confidence: 'high', reason: res.reason };
+  }
+  return { contradiction: true, confidence: 'high', field: 'commit', detail: `commit ${sha} does not exist` };
+}
+
+// ---- network probes (MEDIUM, advisory-only) ----
+function prMergedProbe(body, ctx = {}) {
+  const claim = /merge-evidence-deferred-final|prMerged|PR merged|merged/i.test(body || '');
+  const prNum = (String(body || '').match(/PR\s*#?(\d{1,9})/i) || [])[1];
+  if (!claim || !prNum) return null;
+  const res = runCmd('gh', ['pr', 'view', prNum, '--json', 'state'], { budgetMs: DEFAULT_PROBE_BUDGET_MS, cwd: ctx.cwd });
+  if (!res.ok) return { inconclusive: true, field: 'pr', confidence: 'medium', reason: res.reason };
+  return { contradiction: false, confidence: 'medium' }; // medium never blocks; presence-only check here
+}
+
+// ---- pure-text probes (HIGH) ----
+function acsPassProbe(body) {
+  const text = String(body || '');
+  if (!/all\s+acs?\s+(?:verified\s+)?pass/i.test(text)) return null;
+  const ticked = (text.match(/- \[x\]/gi) || []).length;
+  const unticked = (text.match(/- \[ \]/g) || []).length;
+  if (unticked > 0 && ticked > 0) {
+    return { contradiction: true, confidence: 'high', field: 'acs',
+      detail: `claims all ACs pass but ${unticked} AC checkbox(es) are unticked` };
+  }
+  return { contradiction: false, confidence: 'high' };
+}
+
+const PROBES = [worktreeProbe, commitProbe, prMergedProbe, acsPassProbe];
+
+// Run all applicable probes against an artifact body. Returns { candidates, probeErrors } where
+// candidates are F6 contradiction candidates and probeErrors are inconclusive rows (for incidents.jsonl).
+function runProbes(body, ctx = {}) {
+  const started = Date.now();
+  const candidates = [];
+  const probeErrors = [];
+  for (const probe of PROBES) {
+    if (Date.now() - started > (ctx.totalBudgetMs || TOTAL_BUDGET_MS)) break; // total cap
+    let result;
+    try { result = probe(body, ctx); } catch { result = { inconclusive: true, reason: 'probe-error' }; }
+    if (!result) continue;
+    if (result.inconclusive) {
+      probeErrors.push({ pattern_id: 'probe_error', field: result.field || null,
+        reason: result.reason || 'unknown', severity: 'low' });
+      continue;
+    }
+    if (result.contradiction) {
+      const redacted = redactString(result.detail || '');
+      candidates.push({ class: 'F6', pattern_id: F6_PATTERN_ID, severity: 'high',
+        confidence: result.confidence, field: result.field,
+        detail: typeof redacted === 'string' ? redacted : redacted.text,
+        blocking_eligible: result.confidence === 'high' });
+    }
+  }
+  return { candidates, probeErrors };
+}
+
+module.exports = {
+  runProbes, worktreeProbe, worktreeResidualBranches, commitProbe, prMergedProbe, acsPassProbe,
+  field, PROBES, F6_PATTERN_ID, TOTAL_BUDGET_MS,
+};

--- a/scripts/baton-artifact-builder.js
+++ b/scripts/baton-artifact-builder.js
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+'use strict';
+
+// Schema-validated, deterministic builder for the six baton COMMENT artifacts
+// (Epic #2037 P1.1, Refs #2671). buildArtifact() is PURE — identical structured
+// input yields byte-identical output on any runtime (no Date/random/env reads),
+// which is what the cross-runtime invariant test (P1.4 #2674) asserts. Signer is
+// always DERIVED via agent-signature — never hand-typed — killing the
+// signer-invention defect class. emitBuildDecision() is the separate, impure
+// observability side effect so the build path stays deterministic.
+
+const { canonicalSignerAlias } = require('./signer-alias');
+const { ARTIFACT_SPECS } = require('./baton-artifact-schema');
+
+// teamModel form: `<team>:<model>@<substrate>[/<device>]` (e.g. claude-code:opus@anthropic).
+function deriveSigner(teamModel, role) {
+  const [team = '', rest = ''] = String(teamModel).split(':');
+  const model = (rest.split('@')[0] || '').trim();
+  return canonicalSignerAlias(team, role, model);
+}
+
+function renderField(field, value) {
+  return field.block ? `${field.k}:\n${value}\n\n` : `${field.k}: ${value}\n`;
+}
+
+function isEmpty(value) {
+  return value === null || value === undefined || value === '';
+}
+
+// Rejects unknown keys (typo / prose-leakage guard) and missing required fields.
+function assertValid(spec, name, fields) {
+  const allowed = new Set(spec.fields.map((field) => field.k));
+  for (const key of Object.keys(fields)) {
+    if (!allowed.has(key)) throw new Error(`unknown field '${key}' for ${name}`);
+  }
+  for (const field of spec.fields) {
+    if (field.req && isEmpty(fields[field.k])) {
+      throw new Error(`missing required field '${field.k}' for ${name}`);
+    }
+  }
+}
+
+function buildArtifact(input = {}) {
+  const { role, teamModel, ticket, fields = {} } = input;
+  const name = String(input.artifact || '').toUpperCase();
+  const spec = ARTIFACT_SPECS[name];
+  if (!spec) throw new Error(`unknown artifact: ${name || '(none)'}`);
+  if (!teamModel) throw new Error('teamModel is required');
+  if (!role) throw new Error('role is required');
+  assertValid(spec, name, fields);
+
+  let body = `## ${name}\n\n`;
+  if (spec.ticket && ticket) body += `ticket: #${ticket}\n\n`;
+  for (const field of spec.fields) {
+    const value = fields[field.k];
+    if (isEmpty(value)) continue;
+    body += renderField(field, value);
+  }
+  const signer = deriveSigner(teamModel, role);
+  // Role is ALWAYS rendered as a `Role: <role>` signing line — never a bare
+  // `role:` colon form in prose (which trips the closeout-schema role regex).
+  body += `\nSigned-by: ${signer}\nTeam&Model: ${teamModel}\nRole: ${role}`;
+  return body;
+}
+
+// Impure: appends a schema-v3 decision row. Kept OUT of buildArtifact so the
+// render path is deterministic. Fire-and-forget (best-effort observability).
+function emitBuildDecision(input = {}, file, now) {
+  const { emitV3 } = require('./event-schema-v3');
+  const event = {
+    ts: now || new Date().toISOString(),
+    version: 3,
+    service: 'baton-artifact-builder',
+    env: process.env.CI ? 'ci' : 'local',
+    event: 'artifact_built',
+    artifact: String(input.artifact || '').toUpperCase(),
+    ticket: input.ticket ? `#${input.ticket}` : null,
+    role: input.role || null,
+  };
+  try {
+    emitV3(event, file || `${process.env.HOME}/.megingjord/baton-builds.jsonl`);
+  } catch {
+    // catch-empty: best-effort observability; a failed emit must never block a build.
+  }
+  // Epic #3425 P1-b: the post-build seam IS the review-point. Run the flaw-capture checkpoint
+  // here so detected friction is surfaced for the role to dispose of in flaws_recognized:.
+  // Best-effort + advisory: a failed/disabled checkpoint must never affect the build.
+  let checkpoint = null;
+  try {
+    const { maybeRunCheckpoint } = require('./review-point-checkpoint');
+    checkpoint = maybeRunCheckpoint({ role: input.role, transition: input.role,
+      now: event.ts, team: input.team, runtime: input.runtime });
+  } catch {
+    // catch-empty: checkpoint is advisory observability; never blocks a build.
+  }
+  return { ...event, checkpoint };
+}
+
+module.exports = { buildArtifact, deriveSigner, emitBuildDecision };

--- a/scripts/baton-artifact-schema.js
+++ b/scripts/baton-artifact-schema.js
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+'use strict';
+
+// Declarative field specs for the six baton COMMENT artifacts (Epic #2037 P1.1,
+// Refs #2671). Each artifact lists its fields in canonical render order. The
+// builder (baton-artifact-builder.js) renders structure + signing deterministically;
+// the LLM supplies only field values, and only `block` fields are free-text slots.
+//
+// Field shape: { k: <key>, req: <required?>, block: <multiline narrative slot?> }
+
+function f(k, opts = {}) {
+  return { k, req: !!opts.req, block: !!opts.block };
+}
+
+// MANAGER_HANDOFF — scope + lane + strategy + gates + overlap-handoff declaration
+// (related_tickets + overlap_decision are required by the #2617 overlap gate);
+// phase-gate fields optional.
+const MANAGER = [
+  f('scope', { req: true }),
+  f('lane', { req: true }),
+  f('test_strategy', { req: true }),
+  f('acceptance', { req: true, block: true }),
+  f('gates', { req: true }),
+  f('related_tickets', { req: true }),
+  f('overlap_decision', { req: true }),
+  // #3331: worktree-lifecycle-gate.checkManager requires worktree_branch on
+  // lane:code-change. OPTIONAL here (the gate skips other lanes; the historical
+  // replay corpus predates it), but ALLOWED so the builder can emit a CI-valid
+  // artifact unaided instead of throwing on the unknown key.
+  f('worktree_branch'),
+  f('anneal_tier'),
+  f('phase_gate_satisfied'),
+  f('phase_0_sources'),
+  f('goal_lens'),
+  // #3428 (Epic #3425 P1-a): per-review-point flaw capture. `flaws_recognized`
+  // generalizes the Consultant-only `mid_flight_flaws` to every role. It is a
+  // `block` field (multi-line per-candidate list OR bare `none`) but DELIBERATELY
+  // NOT `req` — making it required would throw buildArtifact on the 17 historical
+  // replay-corpus entries (which predate the field) and break the cross-runtime
+  // byte-identity invariant. This mirrors the worktree-field precedent above
+  // (kept OPTIONAL for corpus back-compat). Requiredness on LIVE artifacts is
+  // enforced by the ADVISORY validator megalint/flaws-recognized.js, the real
+  // enforcement surface. Free cross-model consensus 3/3 (OPTION B) on #3428.
+  f('flaws_recognized', { block: true }),
+];
+
+// COLLABORATOR_HANDOFF — per-AC verification narrative + cross-family preflight.
+const COLLABORATOR = [
+  f('scope', { req: true }),
+  f('test_strategy', { req: true }),
+  f('per_ac_verification', { req: true, block: true }),
+  f('doc_coverage', { block: true }),
+  f('cross_family_rating', { req: true }),
+  f('cross_family_reviewer', { req: true }),
+  f('cross_family_findings', { req: true }),
+  // #3016: the canonical builder must be ABLE to emit cross_family_receipt (#2904) so a
+  // gate-conforming handoff is possible — but keep it OPTIONAL here so the historical
+  // replay-eval corpus (artifacts predating the receipt) still builds. Runtime enforcement
+  // lives in collaborator-handoff.checkCrossFamily, which hard-requires it on live PRs.
+  f('cross_family_receipt', {}),
+  f('reviewer_family', {}),
+  // #3331: worktree-lifecycle-gate.checkCollaborator + collaborator-self-check
+  // require these on lane:code-change. OPTIONAL (lane-gated + corpus back-compat),
+  // but ALLOWED so a builder-produced handoff passes the validators unaided. The
+  // verification key is the literal phrase the self-check scans for, so the block
+  // is detected structurally regardless of the pasted formatChecks() value.
+  f('worktree_branch'),
+  f('worktree_behind_main'),
+  f('Pre-handoff verification', { block: true }),
+  // #3428 (Epic #3425 P1-a): see MANAGER spec note. Block, not req (corpus back-compat).
+  f('flaws_recognized', { block: true }),
+];
+
+// ADMIN_HANDOFF — branch/commit + signer-independence + deploy-sync impact.
+const ADMIN = [
+  f('branch', { req: true }),
+  f('commit', { req: true }),
+  f('signer-independence-check', { req: true }),
+  f('deploy-runtime-impact', { req: true }),
+  // #3428 (Epic #3425 P1-a): see MANAGER spec note. Block, not req (corpus back-compat).
+  f('flaws_recognized', { block: true }),
+];
+
+// CONSULTANT_CLOSEOUT — verdict + rubric + anneal/flaw accounting.
+const CONSULTANT = [
+  f('status', { req: true }),
+  f('verdict', { req: true }),
+  f('verification-timestamp', { req: true }),
+  f('rubric_rating', { req: true }),
+  f('anneal_tickets_filed', { req: true }),
+  f('mid_flight_flaws', { req: true, block: true }),
+  // #3331: worktree-lifecycle-gate.checkConsultant requires worktree_residual_risk
+  // (none | <details>) on non-lightweight lanes. OPTIONAL for back-compat; ALLOWED
+  // so the builder can emit it unaided.
+  f('worktree_residual_risk'),
+  // #3428 (Epic #3425 P1-a): the Consultant gains `flaws_recognized` as the
+  // per-review-point SUPERSET of its existing `mid_flight_flaws` (which stays the
+  // required closeout-aggregation field). Block, not req (corpus back-compat).
+  f('flaws_recognized', { block: true }),
+];
+
+// EPIC_RESCOPE — single narrative synthesis slot (irreducible per #2038).
+const EPIC_RESCOPE = [f('summary', { req: true, block: true })];
+
+// BLOCKER_NOTE — ready-SLA escalation contract fields.
+const BLOCKER = [
+  f('BLOCKER_NOTE', { req: true }),
+  f('owner', { req: true }),
+  f('unblock_condition', { req: true }),
+  f('eta_or_review_time', { req: true }),
+];
+
+// `ticket: #N` line is rendered (after header) only where the artifact carries it.
+const ARTIFACT_SPECS = {
+  MANAGER_HANDOFF: { fields: MANAGER, ticket: false },
+  COLLABORATOR_HANDOFF: { fields: COLLABORATOR, ticket: true },
+  ADMIN_HANDOFF: { fields: ADMIN, ticket: true },
+  CONSULTANT_CLOSEOUT: { fields: CONSULTANT, ticket: true },
+  EPIC_RESCOPE: { fields: EPIC_RESCOPE, ticket: false },
+  BLOCKER_NOTE: { fields: BLOCKER, ticket: true },
+};
+
+module.exports = { ARTIFACT_SPECS, f };

--- a/scripts/baton-comment-build.js
+++ b/scripts/baton-comment-build.js
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+'use strict';
+const { canonicalSignerAlias } = require('./signer-alias');
+const { buildArtifact } = require('./baton-artifact-builder');
+
+// AC1 (#2693): fail loud on unrecognized flags so stale callers surface errors.
+const KNOWN_FLAGS = new Set([
+  'artifact', 'role', 'team-model', 'ticket', 'fields-json',
+  'summary', 'related-tickets', 'overlap-decision',
+]);
+function checkUnknownFlags() {
+  for (const token of process.argv.slice(2)) {
+    const m = token.match(/^--(.+)/);
+    if (m && !KNOWN_FLAGS.has(m[1])) {
+      const known = [...KNOWN_FLAGS].map((f) => `--${f}`).join(', ');
+      process.stderr.write(`error: unknown flag '--${m[1]}'. Recognized: ${known}\n`);
+      process.exit(1);
+    }
+  }
+}
+
+// AC2 (#2693): MANAGER_HANDOFF legacy output must contain all routing fields.
+const MH_REQUIRED = ['scope', 'lane', 'test_strategy', 'acceptance', 'gates'];
+function checkLegacyOutput(artifact, output) {
+  if (artifact !== 'MANAGER_HANDOFF') return;
+  for (const field of MH_REQUIRED) {
+    if (!new RegExp(`(?:^|\\n)${field}\\s*:`).test(output)) {
+      process.stderr.write(`error: MANAGER_HANDOFF missing required field '${field}' in legacy output\n`);
+      process.exit(1);
+    }
+  }
+}
+
+function arg(name, fallback = '') {
+  const i = process.argv.indexOf(`--${name}`);
+  return i >= 0 ? (process.argv[i + 1] || '') : fallback;
+}
+
+function buildBatonComment({ artifact, ticket, role, teamModel, summary = '', relatedTickets = '', overlapDecision = '' }) {
+  const [team = '', modelSub = ''] = String(teamModel || '').split(':');
+  const model = (modelSub.split('@')[0] || '').trim();
+  const signer = canonicalSignerAlias(team, role, model);
+  const head = `## ${artifact}\n\n`;
+  const scope = summary ? `scope: ${summary}\n\n` : '';
+  const refs = ticket ? `ticket: #${ticket}\n\n` : '';
+  const overlap = artifact === 'MANAGER_HANDOFF' && role === 'manager'
+    ? `${relatedTickets ? `related_tickets: ${relatedTickets}\n` : ''}${overlapDecision ? `overlap_decision: ${overlapDecision}\n` : ''}${relatedTickets || overlapDecision ? '\n' : ''}`
+    : '';
+  const sig = `Signed-by: ${signer}\nTeam&Model: ${teamModel}\nRole: ${role}`;
+  return `${head}${scope}${refs}${overlap}${sig}`;
+}
+
+function main() {
+  checkUnknownFlags();
+  const artifact = arg('artifact', 'MANAGER_HANDOFF').toUpperCase();
+  const role = arg('role', 'manager').toLowerCase();
+  const teamModel = arg('team-model', process.env.TEAM_MODEL || '');
+  const ticket = arg('ticket', '');
+  if (!teamModel) {
+    process.stderr.write('Missing --team-model (or TEAM_MODEL env).\n');
+    process.exit(1);
+  }
+  // Structured path (P1.1 #2671): `--fields-json <file>` delegates to the
+  // schema-validated deterministic builder. Default path stays the legacy
+  // free-form renderer for back-compat (AC5).
+  const fieldsJson = arg('fields-json', '');
+  if (fieldsJson) {
+    const fields = JSON.parse(require('fs').readFileSync(fieldsJson, 'utf8'));
+    console.log(buildArtifact({ artifact, role, teamModel, ticket, fields }));
+    return;
+  }
+  const summary = arg('summary', '');
+  const relatedTickets = arg('related-tickets', '');
+  const overlapDecision = arg('overlap-decision', '');
+  const out = buildBatonComment({ artifact, ticket, role, teamModel, summary, relatedTickets, overlapDecision });
+  checkLegacyOutput(artifact, out);
+  console.log(out);
+}
+
+if (require.main === module) main();
+module.exports = { buildBatonComment, buildArtifact };

--- a/scripts/baton-e2e.spec.js
+++ b/scripts/baton-e2e.spec.js
@@ -35,6 +35,35 @@ const CLI = path.join(__dirname, 'baton-comment-build.js');
 const TEAM_MODEL = 'claude-code:opus@anthropic';
 const TICKET = 2064;
 
+// --- Signer-registry provisioning (offline/CI self-containment) ----------------------
+// signer-alias.js loads its registry from <repo>/../inventory/team-model-signatures.json
+// — an OUT-OF-REPO path that is absent on a clean CI checkout (documented drift; see the
+// #2064 self-anneal follow-up). To keep this fixture hermetic we provision a MINIMAL,
+// secret-free registry (roleSurnames + seed only — NO cryptoKeys) at that exact path,
+// but ONLY when it is missing, and we remove ONLY what we created so a real local
+// registry is never clobbered.
+const REGISTRY_PATH = path.join(__dirname, '..', '..', 'inventory', 'team-model-signatures.json');
+const FIXTURE_REGISTRY = {
+  defaultAliasSeed: 'Nova',
+  roleSurnames: { manager: 'Mason', collaborator: 'Harper', admin: 'Reyes', consultant: 'Vale' },
+  substrateTeamMap: {},
+  registry: [{ team: 'claude-code', modelPattern: '.*', aliasSeed: 'Orla' }],
+};
+let _createdRegistryFile = false;
+let _createdRegistryDir = null;
+function provisionRegistry() {
+  if (fs.existsSync(REGISTRY_PATH)) return; // real registry present — use it, touch nothing.
+  const dir = path.dirname(REGISTRY_PATH);
+  if (!fs.existsSync(dir)) { fs.mkdirSync(dir, { recursive: true }); _createdRegistryDir = dir; }
+  fs.writeFileSync(REGISTRY_PATH, JSON.stringify(FIXTURE_REGISTRY, null, 2));
+  _createdRegistryFile = true;
+}
+function teardownRegistry() {
+  if (_createdRegistryFile) { try { fs.unlinkSync(REGISTRY_PATH); } catch (_) {} }
+  if (_createdRegistryDir) { try { fs.rmdirSync(_createdRegistryDir); } catch (_) {} }
+}
+provisionRegistry();
+
 let failures = 0;
 function test(name, fn) {
   try { fn(); console.log('  PASS ' + name); }
@@ -241,6 +270,7 @@ test('AC4 negative: close with no closeout in trail => reopen (guard fires)', ()
 });
 
 // ---- AC5: stress-surface self-report ------------------------------------------------
+teardownRegistry();
 console.log(failures
   ? `\n${failures} test(s) FAILED`
   : '\nAll baton-e2e cycle tests passed (AC1-AC5).');

--- a/scripts/baton-e2e.spec.js
+++ b/scripts/baton-e2e.spec.js
@@ -1,0 +1,247 @@
+#!/usr/bin/env node
+'use strict';
+
+// baton-e2e.spec.js — #2064 (deferred AC5 of closed #1944).
+// End-to-end fixture for the FULL Manager -> Collaborator -> Admin -> Consultant
+// baton cycle. Exercises every handoff gate + status/role label transitions +
+// terminal close against a SYNTHETIC in-memory GitHub ticket.
+//
+// Scope note (rescope ratified by cross-family consensus, receipt 766db29cb883d161,
+// panel groq[meta]=PASS + mistral[mistral]=PASS): the #1148-#3790 ticket universe is a
+// local wiki mirror with no live GitHub remote, and the in-repo E2E precedent
+// (cross-team-consult-e2e.js) is explicitly a synthetic state machine ("no live
+// GitHub; caller supplies registry + timestamps"). This fixture follows that pattern:
+// it drives the REAL baton tooling (scripts/baton-comment-build.js, the same code the
+// operator invokes) and the REAL validators (baton-progression-parity,
+// label-lint-close-protection) over simulated ticket state. No network, deterministic.
+//
+// AC5 retry policy: this fixture is fully deterministic and offline (no network, no
+// clock/random dependence — all timestamps are fixed ISO literals). It therefore needs
+// NO retries; a failure is a real regression, not flake. CI runs it once. If it ever
+// flakes, that itself is the bug to file (do not add blind retries that mask it).
+//
+// Run:  node scripts/baton-e2e.spec.js        (exit 0 = pass, 1 = any failure)
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const { checkBatonProgression, STAGE_ORDER } = require('./baton-progression-parity.js');
+const { decide } = require('./label-lint-close-protection.js');
+
+const CLI = path.join(__dirname, 'baton-comment-build.js');
+const TEAM_MODEL = 'claude-code:opus@anthropic';
+const TICKET = 2064;
+
+let failures = 0;
+function test(name, fn) {
+  try { fn(); console.log('  PASS ' + name); }
+  catch (e) { failures++; console.error('  FAIL ' + name + ': ' + e.message); }
+}
+
+// --- Real CLI invocation: generate a baton artifact via the canonical builder -------
+// Mirrors what a real Admin/Collaborator runs. Uses the structured --fields-json path
+// (the only path that yields a schema-valid MANAGER/COLLABORATOR/ADMIN/CONSULTANT
+// artifact; the --summary legacy path deliberately fails MANAGER field checks).
+function buildViaCLI(artifact, role, fields, { withTicket = true } = {}) {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'baton-e2e-'));
+  const fj = path.join(tmp, 'fields.json');
+  fs.writeFileSync(fj, JSON.stringify(fields));
+  try {
+    const args = ['--artifact', artifact, '--role', role, '--team-model', TEAM_MODEL,
+      '--fields-json', fj];
+    if (withTicket) args.push('--ticket', String(TICKET));
+    const res = spawnSync('node', [CLI, ...args], { encoding: 'utf8' });
+    return { code: res.status, stdout: res.stdout || '', stderr: res.stderr || '' };
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+// --- Synthetic GitHub ticket state machine (no live GitHub) --------------------------
+function initialTicket() {
+  return {
+    number: TICKET,
+    state: 'open',
+    labels: ['type:task', 'status:backlog', 'priority:P3', 'area:governance', 'lane:code-change'],
+    comments: [], // each: { body, createdAt }
+  };
+}
+function setStatus(ticket, status) {
+  ticket.labels = ticket.labels.filter((l) => !l.startsWith('status:'));
+  ticket.labels.push(status);
+}
+function setRole(ticket, role) {
+  ticket.labels = ticket.labels.filter((l) => !l.startsWith('role:'));
+  if (role) ticket.labels.push('role:' + role);
+}
+function postArtifact(ticket, body, createdAt) {
+  ticket.comments.push({ body, createdAt });
+}
+
+// Fixed, ordered timestamps (determinism — no Date.now()).
+const T = {
+  manager: '2026-07-14T01:00:00Z',
+  collaborator: '2026-07-14T02:00:00Z',
+  admin: '2026-07-14T03:00:00Z',
+  consultant: '2026-07-14T04:00:00Z',
+};
+
+// Canonical field sets per artifact (all req: fields per baton-artifact-schema.js).
+const FIELDS = {
+  MANAGER_HANDOFF: {
+    scope: 'E2E fixture exercising the full baton cycle for #2064',
+    lane: 'code-change',
+    test_strategy: 'synthetic-state-machine e2e over real baton tooling',
+    acceptance: '- AC1 synthetic ticket\n- AC2 four artifacts validated\n- AC3 transitions\n- AC4 terminal close\n- AC5 CI stress-surface',
+    gates: 'baton-progression-parity, label-lint-close-protection',
+    related_tickets: 'none',
+    overlap_decision: 'no-overlap',
+  },
+  COLLABORATOR_HANDOFF: {
+    scope: 'implement baton-e2e.spec.js synthetic cycle fixture',
+    test_strategy: 'node scripts/baton-e2e.spec.js (Style B, exit-code signalled)',
+    per_ac_verification: '- AC1: synthetic in-memory ticket, no network\n- AC2: 4 artifacts built + validated\n- AC3: full label/role transition sequence asserted\n- AC4: terminal status:done + resolution:completed asserted\n- AC5: wired into validate-pr.yml',
+    cross_family_rating: 'PASS',
+    cross_family_reviewer: 'groq[meta]+mistral[mistral]',
+    cross_family_findings: 'none (rescope receipt 766db29cb883d161)',
+  },
+  ADMIN_HANDOFF: {
+    branch: 'feat/2064-baton-e2e-fixture',
+    commit: 'PENDING',
+    'signer-independence-check': 'pass (Mason/Harper/Reyes/Vale distinct)',
+    'deploy-runtime-impact': 'none (test-only fixture; no runtime code path)',
+  },
+  CONSULTANT_CLOSEOUT: {
+    status: 'done',
+    verdict: 'approved',
+    'verification-timestamp': T.consultant,
+    rubric_rating: 'G1=pass G2=pass G3=pass',
+    anneal_tickets_filed: 'none',
+    mid_flight_flaws: 'none',
+  },
+};
+
+// Derived signer surnames (never typed — proves signer-independence per role).
+const EXPECTED_SIGNER = {
+  MANAGER_HANDOFF: 'Orla Mason',
+  COLLABORATOR_HANDOFF: 'Orla Harper',
+  ADMIN_HANDOFF: 'Orla Reyes',
+  CONSULTANT_CLOSEOUT: 'Orla Vale',
+};
+
+const ROLE_OF = {
+  MANAGER_HANDOFF: 'manager',
+  COLLABORATOR_HANDOFF: 'collaborator',
+  ADMIN_HANDOFF: 'admin',
+  CONSULTANT_CLOSEOUT: 'consultant',
+};
+
+console.log('baton-e2e.spec: full Manager->Collaborator->Admin->Consultant cycle (#2064)');
+
+// ---- AC1: synthetic ticket is fully in-memory (no network) --------------------------
+const ticket = initialTicket();
+test('AC1 synthetic ticket starts at status:backlog, open, no comments', () => {
+  assert.equal(ticket.state, 'open');
+  assert.ok(ticket.labels.includes('status:backlog'));
+  assert.equal(ticket.comments.length, 0);
+});
+
+// ---- AC2: generate + validate all four baton artifacts via the REAL CLI --------------
+const artifacts = {}; // ARTIFACT -> body
+for (const artifact of STAGE_ORDER) {
+  const role = ROLE_OF[artifact];
+  test(`AC2 build ${artifact} via real baton-comment-build.js`, () => {
+    const r = buildViaCLI(artifact, role, FIELDS[artifact], { withTicket: artifact !== 'MANAGER_HANDOFF' });
+    assert.equal(r.code, 0, `CLI exit ${r.code}: ${r.stderr}`);
+    assert.match(r.stdout, new RegExp(`##\\s+${artifact}\\b`), 'artifact header present');
+    assert.match(r.stdout, new RegExp(`Signed-by: ${EXPECTED_SIGNER[artifact]}\\b`),
+      `derived signer must be ${EXPECTED_SIGNER[artifact]}`);
+    assert.match(r.stdout, new RegExp(`Role: ${role}\\b`), 'role line present');
+    artifacts[artifact] = r.stdout;
+  });
+}
+
+test('AC2 signer-independence: all four role signers are distinct', () => {
+  const signers = STAGE_ORDER.map((a) => (artifacts[a].match(/Signed-by: (.+)/) || [])[1]);
+  assert.equal(new Set(signers).size, 4, `expected 4 distinct signers, got ${JSON.stringify(signers)}`);
+});
+
+test('AC2 real schema validation rejects a missing required field', () => {
+  // ADMIN_HANDOFF without required "commit" must fail at the builder (real validator).
+  const r = buildViaCLI('ADMIN_HANDOFF', 'admin', { branch: 'x' });
+  assert.notEqual(r.code, 0, 'CLI must reject artifact missing a required field');
+  assert.match(r.stderr, /commit/i, 'error should name the missing field');
+});
+
+// ---- AC3: drive the full status/role label transition sequence -----------------------
+const statusTrail = [];
+const roleTrail = [];
+function advance(artifact, status, role, ts) {
+  postArtifact(ticket, artifacts[artifact], ts);
+  setStatus(ticket, status);
+  setRole(ticket, role);
+  statusTrail.push(status);
+  roleTrail.push(role);
+}
+
+test('AC3 full baton progression is contiguous + time-ordered (real validator)', () => {
+  advance('MANAGER_HANDOFF', 'status:in-progress', 'collaborator', T.manager);
+  advance('COLLABORATOR_HANDOFF', 'status:review', 'admin', T.collaborator);
+  advance('ADMIN_HANDOFF', 'status:review', 'consultant', T.admin);
+  advance('CONSULTANT_CLOSEOUT', 'status:review', 'consultant', T.consultant);
+  assert.equal(checkBatonProgression(ticket.comments), null, 'ordered full cycle must pass');
+});
+
+test('AC3 status trail follows backlog->in-progress->review sequence', () => {
+  assert.deepEqual(statusTrail,
+    ['status:in-progress', 'status:review', 'status:review', 'status:review']);
+});
+
+test('AC3 negative: out-of-order baton is rejected', () => {
+  const bad = [
+    { body: artifacts.COLLABORATOR_HANDOFF, createdAt: T.manager },
+    { body: artifacts.MANAGER_HANDOFF, createdAt: T.collaborator },
+  ];
+  const v = checkBatonProgression(bad);
+  assert.ok(v && v.rule === 'baton-progression-out-of-order', `expected out-of-order, got ${JSON.stringify(v)}`);
+});
+
+test('AC3 negative: skipped-step (gap) baton is rejected', () => {
+  const bad = [
+    { body: artifacts.MANAGER_HANDOFF, createdAt: T.manager },
+    { body: artifacts.ADMIN_HANDOFF, createdAt: T.admin },
+  ];
+  const v = checkBatonProgression(bad);
+  assert.ok(v && v.rule === 'baton-progression-gap', `expected gap, got ${JSON.stringify(v)}`);
+});
+
+// ---- AC4: terminal close — PR/CI/merge modeled as synthetic close transition ----------
+test('AC4 closeout present + status:review => auto-transition to status:done', () => {
+  const d = decide({ state: 'closed', labels: ticket.labels, comments: ticket.comments });
+  assert.equal(d.action, 'auto-transition', `expected auto-transition, got ${JSON.stringify(d)}`);
+  assert.ok(d.addLabels.includes('status:done'), 'terminal status:done added');
+  // Ticket-level close uses resolution:completed (resolution:released is the Epic/release variant).
+  assert.ok(d.addLabels.includes('resolution:completed'), 'resolution:completed added');
+  assert.ok(d.removeLabels.includes('role:consultant'), 'role label stripped on close');
+  // Apply the transition to the synthetic ticket -> assert terminal state.
+  for (const l of d.removeLabels) ticket.labels = ticket.labels.filter((x) => x !== l);
+  for (const l of d.addLabels) if (!ticket.labels.includes(l)) ticket.labels.push(l);
+  ticket.state = 'closed';
+  assert.ok(ticket.labels.includes('status:done'));
+  assert.ok(ticket.labels.includes('resolution:completed'));
+  assert.equal(ticket.state, 'closed');
+});
+
+test('AC4 negative: close with no closeout in trail => reopen (guard fires)', () => {
+  const d = decide({ state: 'closed', labels: ['status:review'], comments: [] });
+  assert.equal(d.action, 'reopen', `expected reopen, got ${JSON.stringify(d)}`);
+});
+
+// ---- AC5: stress-surface self-report ------------------------------------------------
+console.log(failures
+  ? `\n${failures} test(s) FAILED`
+  : '\nAll baton-e2e cycle tests passed (AC1-AC5).');
+process.exit(failures ? 1 : 0);

--- a/scripts/baton-progression-parity.js
+++ b/scripts/baton-progression-parity.js
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+'use strict';
+// Baton-progression continuity guardrail (#2957).
+//
+// Enforces that the baton artifacts present on a linked issue form a CONTIGUOUS,
+// monotonically time-ordered prefix of:
+//   MANAGER_HANDOFF -> COLLABORATOR_HANDOFF -> ADMIN_HANDOFF -> CONSULTANT_CLOSEOUT
+//
+// This complements pre-pr-gate's checkBatonCompleteness (#1896), which only checks
+// artifact PRESENCE. The #2940 incident showed Copilot Auto-mode "proceeding without
+// explicit baton artifact continuity at each step" — i.e. a present artifact set that
+// skips a role or posts artifacts out of order. That is what this module denies.
+//
+// Route-invariance is the core anti-drift property (#2957: "Auto model selection must
+// not reduce governance discipline"). No model/route/auto-mode signal is read by the
+// decision functions, so Copilot Auto-mode receives IDENTICAL enforcement to frontier
+// routing. The evaluate() wrapper makes that invariant explicit and testable.
+
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const STAGE_ORDER = [
+  'MANAGER_HANDOFF',
+  'COLLABORATOR_HANDOFF',
+  'ADMIN_HANDOFF',
+  'CONSULTANT_CLOSEOUT',
+];
+const INCIDENT_PATTERN_ID = 'auto-mode-baton-progression-gap';
+const SUMMARY_MAX_LEN = 200; // _summary cap for the schema-v3 incident record
+
+// Latest createdAt (epoch ms) per baton stage present in the comment list.
+// Tolerant of malformed input: non-array, null comments, non-string bodies, and
+// unparseable timestamps are skipped rather than thrown (G6 resilience).
+function latestTimestampsByStage(comments) {
+  const timestamps = {};
+  const list = Array.isArray(comments) ? comments : [];
+  for (const comment of list) {
+    const body = comment && typeof comment.body === 'string' ? comment.body : '';
+    if (!body) continue;
+    const createdAt = comment && comment.createdAt ? Date.parse(comment.createdAt) : NaN;
+    if (!Number.isFinite(createdAt)) continue;
+    for (const stage of STAGE_ORDER) {
+      if (body.includes(stage)) {
+        if (timestamps[stage] === undefined || createdAt > timestamps[stage]) {
+          timestamps[stage] = createdAt;
+        }
+      }
+    }
+  }
+  return timestamps;
+}
+
+// Returns a violation { rule, detail } when the present artifacts are NOT a
+// contiguous, time-ordered prefix of STAGE_ORDER; otherwise null. Model-agnostic.
+function checkBatonProgression(comments) {
+  const timestamps = latestTimestampsByStage(comments);
+  const present = STAGE_ORDER.map((stage) => timestamps[stage] !== undefined);
+  const lastPresentIndex = present.lastIndexOf(true);
+  if (lastPresentIndex < 0) return null; // no artifacts yet — nothing to order
+
+  // Contiguity: every earlier stage must be present (no skipped step).
+  for (let i = 0; i < lastPresentIndex; i++) {
+    if (!present[i]) {
+      return {
+        rule: 'baton-progression-gap',
+        detail:
+          `${STAGE_ORDER[lastPresentIndex]} present but earlier ${STAGE_ORDER[i]} is ` +
+          'missing — baton continuity skipped a step before a privileged action.',
+      };
+    }
+  }
+  // Monotonic ordering: no present stage may predate the stage before it.
+  for (let i = 1; i <= lastPresentIndex; i++) {
+    if (timestamps[STAGE_ORDER[i]] < timestamps[STAGE_ORDER[i - 1]]) {
+      return {
+        rule: 'baton-progression-out-of-order',
+        detail:
+          `${STAGE_ORDER[i]} is timestamped before ${STAGE_ORDER[i - 1]} — baton ` +
+          'artifacts were posted out of role order.',
+      };
+    }
+  }
+  return null;
+}
+
+// Route-invariant evaluation entrypoint. `context` may carry a model/route/auto-mode
+// hint from the runtime; it is intentionally IGNORED so governance discipline is
+// identical regardless of routing. Do not branch on context here — that is the bug
+// class #2957 exists to prevent.
+function evaluate(comments, context) {
+  void context; // deliberately unused — see route-invariance contract above
+  return checkBatonProgression(comments);
+}
+
+// Append a Tier-2 incident capturing the progression gap for the anneal detector.
+// Emission failure is swallowed (returns false) — observability must never block a
+// gate (G6/G8).
+function emitProgressionIncident(violation, opts = {}) {
+  const file =
+    opts.incidentsPath || path.join(os.homedir(), '.megingjord', 'incidents.jsonl');
+  const record = {
+    ts: opts.now ? new Date(opts.now).toISOString() : new Date().toISOString(),
+    version: 3,
+    service: 'baton-progression-parity',
+    env: 'local',
+    event: 'kill-switch-trip',
+    pattern_id: INCIDENT_PATTERN_ID,
+    rule: violation.rule,
+    _summary: String(violation.detail || '').slice(0, SUMMARY_MAX_LEN),
+  };
+  try {
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.appendFileSync(file, JSON.stringify(record) + '\n');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+module.exports = {
+  checkBatonProgression,
+  evaluate,
+  latestTimestampsByStage,
+  emitProgressionIncident,
+  STAGE_ORDER,
+  INCIDENT_PATTERN_ID,
+};

--- a/scripts/event-schema-otel-genai.js
+++ b/scripts/event-schema-otel-genai.js
@@ -1,0 +1,60 @@
+// tier: 2
+// event-schema-otel-genai.js — OTel GenAI field-level conformance validator.
+// Companion to event-schema-v3.js isOtelGenAI (prefix-only detection).
+// Provides schema-aware validation per OTel GenAI Semantic Conventions:
+// https://opentelemetry.io/docs/specs/semconv/gen-ai/
+//
+// G3 value: conformant gen_ai.usage.* fields enable Phoenix/Langfuse/Helicone
+// to correctly ingest harness telemetry for per-provider cost attribution,
+// directly supporting the cost-ascending mandate.
+// Refs #1375 / #1339
+'use strict';
+
+const OTEL_GENAI_SYSTEMS = [
+  'openai', 'anthropic', 'ollama', 'cohere', 'gemini', 'vertex_ai',
+  'bedrock', 'other_system', 'aws.sagemaker', 'az.ai_inference',
+];
+
+const GENAI_PREFIX = 'gen_ai.';
+
+// P1-5 (#2232): map a wrapper provider id -> a valid OTel gen_ai.system value.
+// Providers that are not semconv systems (openrouter/litellm/copilot/groq/cerebras)
+// and any unknown provider fall back to the semconv catch-all 'other_system'.
+// Return is ALWAYS a member of OTEL_GENAI_SYSTEMS.
+function providerToGenAiSystem(provider) {
+  return OTEL_GENAI_SYSTEMS.includes(provider) ? provider : 'other_system';
+}
+
+function validateUsageField(event, field, errors) {
+  const value = event[field];
+  if (value !== undefined && (!Number.isInteger(value) || value < 0)) {
+    errors.push(`${field} must be a non-negative integer`);
+  }
+}
+
+function isValidGenAI(event) {
+  if (!event || typeof event !== 'object') {
+    return { ok: true, errors: [], warnings: ['input not an object'] };
+  }
+  const keys = Object.keys(event).filter(k => k.startsWith(GENAI_PREFIX));
+  if (keys.length === 0) {
+    return { ok: true, errors: [], warnings: ['no gen_ai.* fields'] };
+  }
+  const errors = [];
+  if (event['gen_ai.system'] !== undefined &&
+      !OTEL_GENAI_SYSTEMS.includes(event['gen_ai.system'])) {
+    errors.push(
+      `gen_ai.system: unrecognized value "${event['gen_ai.system']}" ` +
+      `— not in OTel GenAI canonical enum`
+    );
+  }
+  if (event['gen_ai.request.model'] !== undefined &&
+      typeof event['gen_ai.request.model'] !== 'string') {
+    errors.push('gen_ai.request.model must be a string');
+  }
+  validateUsageField(event, 'gen_ai.usage.input_tokens', errors);
+  validateUsageField(event, 'gen_ai.usage.output_tokens', errors);
+  return { ok: errors.length === 0, errors, warnings: [] };
+}
+
+module.exports = { isValidGenAI, OTEL_GENAI_SYSTEMS, GENAI_PREFIX, providerToGenAiSystem };

--- a/scripts/event-schema-v3.js
+++ b/scripts/event-schema-v3.js
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+// tier: 2
+// event-schema-v3.js — Unified event schema v3 for all *.jsonl logging surfaces.
+// Epic #1339 / #1353. Foundation for harness + HAMR observability.
+//
+// V3 generalizes the anneal v2 schema (scripts/global/anneal-event-schema.js)
+// to cover ALL logging surfaces: incidents.jsonl, cache-stats.jsonl,
+// events.jsonl, and future surfaces. Includes OpenTelemetry GenAI namespace
+// support per R&D Thread 1.
+//
+// Backward-compat: v1 (no version) and v2 anneal events upgrade-on-read. v1/v2
+// readers ignore unknown v3 fields.
+'use strict';
+
+const V3 = 3;
+const V3_REQUIRED = ['ts', 'version', 'service', 'env', 'event'];
+const V3_RECOMMENDED = ['trace_id', 'session_id'];
+const VALID_ENVS = ['local', 'ci', 'cloudflare', 'test'];
+const SUMMARY_MAX = 200;
+const OTEL_GENAI_PREFIX = 'gen_ai.';
+
+const V2_ANNEAL_FIELDS = ['tier', 'trigger_role', 'trigger_type', 'pattern_id',
+  'severity', 'evidence', 'ticket_ref', 'epic_ref'];
+
+function detectVersion(event) {
+  if (!event || typeof event !== 'object') return 0;
+  if (event.version === undefined) return 1;
+  return event.version;
+}
+
+function isValidV3(event) {
+  const errors = [];
+  if (!event || typeof event !== 'object') {
+    return { ok: false, errors: ['event must be an object'] };
+  }
+  if (event.version !== V3) errors.push(`version must be ${V3}`);
+  for (const field of V3_REQUIRED) {
+    if (event[field] === undefined) errors.push(`missing required v3 field: ${field}`);
+  }
+  if (event.env !== undefined && !VALID_ENVS.includes(event.env)) {
+    errors.push(`env must be one of ${VALID_ENVS.join('|')}`);
+  }
+  if (event._summary !== undefined) {
+    if (typeof event._summary !== 'string') errors.push('_summary must be a string');
+    else if (event._summary.length > SUMMARY_MAX) {
+      errors.push(`_summary exceeds ${SUMMARY_MAX} chars`);
+    }
+  }
+  return { ok: errors.length === 0, errors };
+}
+
+function upgradeToV3(event, surfaceContext = {}) {
+  const ver = detectVersion(event);
+  const ts = event.ts || event.timestamp || new Date().toISOString();
+  const base = {
+    version: V3,
+    ts,
+    service: surfaceContext.service || event.service || 'unknown',
+    env: surfaceContext.env || event.env || 'local',
+    event: surfaceContext.event || event.event || 'legacy',
+    trace_id: event.trace_id || event.session_id || null,
+    session_id: event.session_id || 'legacy',
+    surface: surfaceContext.surface || event.surface || null,
+  };
+  // Preserve v2 anneal fields if present (additive)
+  if (ver === 2) {
+    for (const fieldName of V2_ANNEAL_FIELDS) {
+      if (event[fieldName] !== undefined) base[fieldName] = event[fieldName];
+    }
+  }
+  // Preserve all v1 fields too (consumer compat)
+  return Object.assign({}, event, base, { version: V3 });
+}
+
+function normalize(event, surfaceContext = {}) {
+  if (detectVersion(event) === V3) return event;
+  return upgradeToV3(event, surfaceContext);
+}
+
+function isOtelGenAI(event) {
+  if (!event || typeof event !== 'object') return false;
+  return Object.keys(event).some(k => k.startsWith(OTEL_GENAI_PREFIX));
+}
+
+function emitV3(event, file) {
+  const enriched = Object.assign({
+    team: process.env.HAMR_TEAM || process.env.MEGINGJORD_TEAM || 'unknown',
+    trigger_role: 'system',
+  }, event);
+  if (!enriched.team) enriched.team = 'unknown';
+  if (!enriched.trigger_role) enriched.trigger_role = 'system';
+  const { ok, errors } = isValidV3(enriched);
+  if (!ok) throw new Error(`Invalid v3 event: ${errors.join('; ')}`);
+  const fs = require('fs');
+  const path = require('path');
+  const dir = path.dirname(file);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  fs.appendFileSync(file, JSON.stringify(event) + '\n', 'utf8');
+}
+
+function readEvents(file, surfaceContext = {}) {
+  const fs = require('fs');
+  if (!fs.existsSync(file)) return [];
+  return fs.readFileSync(file, 'utf8')
+    .split('\n').filter(Boolean)
+    .map(line => { try { return JSON.parse(line); } catch { return null; } })
+    .filter(Boolean)
+    .map(ev => normalize(ev, surfaceContext));
+}
+
+const { isValidGenAI, OTEL_GENAI_SYSTEMS } = require('./event-schema-otel-genai');
+
+module.exports = {
+  V3, V3_REQUIRED, V3_RECOMMENDED, VALID_ENVS, SUMMARY_MAX, OTEL_GENAI_PREFIX,
+  V2_ANNEAL_FIELDS,
+  detectVersion, isValidV3, upgradeToV3, normalize, isOtelGenAI,
+  isValidGenAI, OTEL_GENAI_SYSTEMS,
+  emitV3, readEvents,
+};

--- a/scripts/friction-event.js
+++ b/scripts/friction-event.js
@@ -1,0 +1,80 @@
+'use strict';
+// friction-event.js — structured per-team friction-event schema (#3165, Epic #3008/#3095).
+//
+// A "friction" is any harness pothole an operator hits mid-flight: a gate false-block, a
+// workaround, a retry, a fleet timeout. Today these are captured ad hoc in prose (e.g. the
+// Cursor Team's 18-item manual log on #3008) or lost, so cross-team recurrence goes
+// undetected. emitFriction writes a REDACTED v3 event tagged `tier: 1` + `pattern_id` +
+// `severity` to incidents.jsonl, so the existing anneal-tier2-autofile recurrence model
+// (classifyTier1: count >= 2 by pattern_id) routes recurring frictions to Tier-2 with no
+// extra plumbing. Cross-team weighting lives in friction-recurrence.js.
+
+const os = require('os');
+const path = require('path');
+const fs = require('fs');
+const { V3, emitV3 } = require('./event-schema-v3');
+const { redactEvent } = require('./log-redaction');
+
+const INCIDENTS_FILE = path.join(os.homedir(), '.megingjord', 'incidents.jsonl');
+const CATALOG_FILE = path.join(__dirname, '..', '..', 'config', 'friction-pattern-catalog.json');
+const FRICTION_EVENT = 'governance.friction';
+const SEVERITIES = ['low', 'medium', 'high', 'critical'];
+const DEFAULT_SEVERITY = 'low';
+
+function buildFrictionEvent(patternId, fields = {}, now) {
+  const severity = SEVERITIES.includes(fields.severity) ? fields.severity : DEFAULT_SEVERITY;
+  const event = {
+    version: V3,
+    ts: now || new Date().toISOString(),
+    service: 'friction',
+    env: fields.env || 'local',
+    event: FRICTION_EVENT,
+    tier: 1, // tier:1 => consumed by the anneal-tier2-autofile recurrence detector
+    pattern_id: patternId,
+    team: fields.team || 'unknown',
+    runtime: fields.runtime || 'unknown',
+    role: fields.role || null,
+    surface: fields.surface || null,
+    severity,
+    workaround: fields.workaround || null,
+    trigger_role: fields.role || 'system',
+    trigger_type: 'friction',
+  };
+  if (fields.cost !== undefined && fields.cost !== null) event.cost = fields.cost;
+  if (fields.detail) event.detail = fields.detail;
+  return event;
+}
+
+function isValidFriction(event) {
+  const errors = [];
+  if (!event || typeof event !== 'object') return { ok: false, errors: ['event must be an object'] };
+  if (event.event !== FRICTION_EVENT) errors.push(`event must be ${FRICTION_EVENT}`);
+  if (!event.pattern_id) errors.push('missing pattern_id');
+  if (event.tier !== 1) errors.push('friction events must be tier:1');
+  if (!SEVERITIES.includes(event.severity)) errors.push(`severity must be one of ${SEVERITIES.join('|')}`);
+  return { ok: errors.length === 0, errors };
+}
+
+// G4: redact at the instrumentation site, never scrub at storage.
+function emitFriction(patternId, fields = {}, opts = {}) {
+  const file = opts.file || INCIDENTS_FILE;
+  // redactEvent returns { event, hits }; we persist the redacted event only.
+  const { event } = redactEvent(buildFrictionEvent(patternId, fields, opts.now));
+  const { ok, errors } = isValidFriction(event);
+  if (!ok) throw new Error(`invalid friction event: ${errors.join('; ')}`);
+  emitV3(event, file);
+  return event;
+}
+
+function loadFrictionCatalog(file = CATALOG_FILE) {
+  try { return JSON.parse(fs.readFileSync(file, 'utf8')); } catch { return { patterns: [] }; }
+}
+
+function isKnownPattern(patternId, catalog = loadFrictionCatalog()) {
+  return (catalog.patterns || []).some((entry) => entry.pattern_id === patternId);
+}
+
+module.exports = {
+  FRICTION_EVENT, SEVERITIES, INCIDENTS_FILE, CATALOG_FILE,
+  buildFrictionEvent, isValidFriction, emitFriction, loadFrictionCatalog, isKnownPattern,
+};

--- a/scripts/label-lint-close-protection.js
+++ b/scripts/label-lint-close-protection.js
@@ -1,0 +1,64 @@
+'use strict';
+// label-lint-close-protection — pure decision logic for the auto-transition
+// vs auto-reopen branch of label-lint.yml. Extracted so the race condition
+// fix (#1515) is unit-testable without a live GitHub API.
+//
+// Decision rules:
+// 1. If issue is open or already terminal → no-op.
+// 2. Phase-0 promotion guard (#2678): if the issue is a research-first Epic
+//    whose Phase-0 is green-complete but with zero Phase-1 children, block the
+//    close (reopen) regardless of closeout — the close is premature.
+// 3. If issue closed without a terminal label AND a CONSULTANT_CLOSEOUT
+//    comment exists AND the pre-close status is `status:review` OR
+//    `status:testing` (the two states the baton produces just before close):
+//      → auto-transition to status:done + resolution:completed.
+// 4. Otherwise (closed without terminal, no closeout in trail) → reopen
+//    and post the "Close blocked" advisory.
+//
+// Pre-fix: rule 3 required `status:review` ONLY, missing the merge-via-
+// `Closes #N`-trailer path that fires at `status:testing`. Caused
+// reopen-on-merge friction across #1506/#1508/#1512.
+
+const CLOSEOUT_HEADER_RE = /(^|\n)\s*(?:\*\*|##\s+)?CONSULTANT_CLOSEOUT(?:_EPIC_CLOSEOUT)?\b/;
+const TERMINAL_LABELS = ['status:done', 'status:cancelled'];
+const VALID_PRE_CLOSE_LABELS = ['status:review', 'status:testing'];
+
+function hasCloseoutComment(comments) {
+  return (comments || []).some((c) => CLOSEOUT_HEADER_RE.test((c && c.body) || ''));
+}
+
+function decide({ state, labels = [], comments = [], phase0MissingPhase1 = false }) {
+  if (state !== 'closed') return { action: 'noop', reason: 'issue-open' };
+  if (labels.some((l) => TERMINAL_LABELS.includes(l))) {
+    return { action: 'noop', reason: 'already-terminal' };
+  }
+  // #2678: a research-first Epic with green Phase-0 and no Phase-1 children
+  // must not close — the Phase-1 chain is missing. Block ahead of any
+  // closeout-based auto-transition.
+  if (phase0MissingPhase1) {
+    return { action: 'block-close', reopen: true, reason: 'phase0-green-no-phase1-children' };
+  }
+  const closeoutPresent = hasCloseoutComment(comments);
+  const preCloseLabel = VALID_PRE_CLOSE_LABELS.find((l) => labels.includes(l));
+  if (closeoutPresent && preCloseLabel) {
+    // #1380: strip ALL status:* labels (not just preCloseLabel) to prevent
+    // Rule 1 multi-status drift when a stale label like status:backlog lingers.
+    const allStatusLabels = labels.filter(l => l.startsWith('status:'));
+    return {
+      action: 'auto-transition',
+      from: preCloseLabel,
+      removeLabels: [...allStatusLabels, 'role:consultant'],
+      addLabels: ['status:done', 'resolution:completed'],
+      reason: `closeout-present-from-${preCloseLabel}`,
+    };
+  }
+  return {
+    action: 'reopen',
+    reason: closeoutPresent ? 'closeout-without-valid-pre-close-label' : 'no-closeout-in-trail',
+  };
+}
+
+module.exports = {
+  decide, hasCloseoutComment,
+  CLOSEOUT_HEADER_RE, TERMINAL_LABELS, VALID_PRE_CLOSE_LABELS,
+};

--- a/scripts/log-redaction.js
+++ b/scripts/log-redaction.js
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+// log-redaction.js — PII/secret redaction for harness logs.
+// Epic #1339 / #1358. Implements R&D Thread 5 "prevent at instrumentation"
+// strategy. Patterns in config/redaction-patterns.json.
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+
+const PATTERNS_FILE = path.join(__dirname, '..', '..', 'config', 'redaction-patterns.json');
+
+function loadPatterns(file = PATTERNS_FILE) {
+  if (!fs.existsSync(file)) return [];
+  const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+  return (data.patterns || []).map(pattern => ({
+    ...pattern,
+    compiled: new RegExp(pattern.regex, 'g'),
+  }));
+}
+
+let _patterns = null;
+function getPatterns() {
+  if (_patterns === null) _patterns = loadPatterns();
+  return _patterns;
+}
+
+/**
+ * Apply redaction patterns to a single string.
+ * @param {string} input
+ * @param {Array}  patterns  optional override
+ * @returns {{ text: string, hits: Array<{id, action}> }}
+ */
+function redactString(input, patterns = getPatterns()) {
+  if (typeof input !== 'string') return { text: input, hits: [] };
+  let text = input;
+  const hits = [];
+  for (const pattern of patterns) {
+    pattern.compiled.lastIndex = 0;
+    if (!pattern.compiled.test(text)) continue;
+    pattern.compiled.lastIndex = 0;
+    text = text.replace(pattern.compiled, (match) => {
+      hits.push({ id: pattern.id, action: pattern.action });
+      if (pattern.action === 'redact') return pattern.replacement || '<REDACTED>';
+      if (pattern.action === 'hash') return `<HASH:${hashShort(match)}>`;
+      if (pattern.action === 'drop') return '';
+      return match;
+    });
+  }
+  return { text, hits };
+}
+
+function hashShort(input) {
+  return crypto.createHash('sha256').update(input).digest('hex').slice(0, 12);
+}
+
+/**
+ * Apply redaction to a structured event (recursive over string fields).
+ * Returns the redacted event + aggregated hits.
+ * @param {object} event
+ * @param {Array}  patterns
+ * @returns {{ event: object, hits: Array }}
+ */
+function redactEvent(event, patterns = getPatterns()) {
+  const allHits = [];
+  function walk(node) {
+    if (typeof node === 'string') {
+      const result = redactString(node, patterns);
+      allHits.push(...result.hits);
+      return result.text;
+    }
+    if (Array.isArray(node)) return node.map(walk);
+    if (node && typeof node === 'object') {
+      const out = {};
+      for (const key of Object.keys(node)) out[key] = walk(node[key]);
+      return out;
+    }
+    return node;
+  }
+  return { event: walk(event), hits: allHits };
+}
+
+/**
+ * Wrap a write function so that any object passed through it is redacted first.
+ * Used at instrumentation site (prevent, not scrub).
+ * @param {function} writeFn  receives the (redacted) event
+ * @returns {function} new write fn
+ */
+function wrapWrite(writeFn) {
+  const patterns = getPatterns();
+  return function wrappedWrite(event) {
+    const result = redactEvent(event, patterns);
+    return writeFn(result.event);
+  };
+}
+
+/**
+ * Pre-LLM-consumption redaction hook. When log content is being included in
+ * an LLM prompt (high-risk for prompt injection via leaked secrets), pass
+ * through this hook first.
+ * @param {string} promptFragment
+ * @returns {string}
+ */
+function sanitizeForLLM(promptFragment) {
+  return redactString(promptFragment, getPatterns()).text;
+}
+
+module.exports = {
+  loadPatterns, getPatterns, redactString, redactEvent,
+  wrapWrite, sanitizeForLLM, hashShort, PATTERNS_FILE,
+};

--- a/scripts/review-point-checkpoint.js
+++ b/scripts/review-point-checkpoint.js
@@ -1,0 +1,87 @@
+'use strict';
+// review-point-checkpoint — the per-review-point flaw-capture checkpoint (Epic #3425 P1-b).
+//
+// A review-point is any baton handoff/transition. At build time (the baton-artifact-builder seam)
+// this checkpoint (1) reads the friction candidate feed accumulated since the previous review-point
+// from incidents.jsonl, keyed by session + window; (2) surfaces those candidates so the role must
+// dispose of each in its flaws_recognized: block; and (3) emits ONE checkpoint run-event per
+// review-point via the existing friction_event schema (surface = review-point:<role-transition>),
+// so a MISSING checkpoint at a review-point is itself detectable by the #1855 SessionEnd backstop
+// (P1-e). SHIPS ADVISORY: it never blocks the build; emission is best-effort.
+//
+// The AC-R4 asserted-vs-observed probes (P1-c #3430) plug in via opts.probes — absent here, the
+// checkpoint surfaces only the incidents feed.
+
+const os = require('os');
+const path = require('path');
+const fs = require('fs');
+const { emitFriction } = require('./friction-event');
+
+const INCIDENTS_FILE = path.join(os.homedir(), '.megingjord', 'incidents.jsonl');
+const CHECKPOINT_PATTERN_ID = 'review-point-checkpoint';
+const FRICTION_EVENT = 'governance.friction';
+
+// Read friction candidates from incidents.jsonl for this review-point window: tier-1 friction rows
+// at or after sinceTs (and not the checkpoint's own run-events). Malformed rows are skipped.
+function collectCandidates(opts = {}) {
+  const file = opts.incidentsPath || INCIDENTS_FILE;
+  const sinceTs = opts.sinceTs ? Date.parse(opts.sinceTs) : 0;
+  let lines;
+  try { lines = fs.readFileSync(file, 'utf8').split('\n').filter(Boolean); }
+  catch { return []; }
+  const candidates = [];
+  for (const line of lines) {
+    let row;
+    try { row = JSON.parse(line); } catch { continue; } // chaos-tolerant: skip malformed rows
+    if (row.event !== FRICTION_EVENT || row.tier !== 1) continue;
+    if (row.pattern_id === CHECKPOINT_PATTERN_ID) continue; // never surface our own run-events
+    const ts = Date.parse(row.ts || '');
+    if (Number.isFinite(sinceTs) && Number.isFinite(ts) && ts < sinceTs) continue;
+    candidates.push({ pattern_id: row.pattern_id, severity: row.severity || 'low',
+      surface: row.surface || null, detail: row.detail || null, ts: row.ts || null });
+  }
+  return candidates;
+}
+
+// Epic #3425 P1-c: run the F6 asserted-vs-observed probes against the artifact body, if one was
+// provided. Returns F6 contradiction candidates ([] when no body / probes unavailable / error).
+function runArtifactProbes(input = {}) {
+  if (!input.artifactBody) return [];
+  try {
+    const { runProbes } = require('./asserted-vs-observed-probes');
+    return runProbes(input.artifactBody, { mainRef: input.mainRef, cwd: input.cwd }).candidates;
+  } catch { return []; } // probes are advisory; never block the checkpoint
+}
+
+// Run the checkpoint for a review-point: collect candidates (feed + any injected probe candidates),
+// emit one run-event, and return the surfaced set for the role to dispose of. Never throws.
+function runCheckpoint(input = {}) {
+  const transition = String(input.transition || input.role || 'unknown');
+  const surface = `review-point:${transition}`;
+  const feed = collectCandidates({ incidentsPath: input.incidentsPath, sinceTs: input.sinceTs });
+  const probeCandidates = Array.isArray(input.probeCandidates) ? input.probeCandidates : [];
+  // Epic #3425 P1-c: when the artifact body is available, run the asserted-vs-observed (F6) probes
+  // and surface their contradiction candidates too. Best-effort + advisory: probe failure is ignored.
+  const probed = runArtifactProbes(input);
+  const candidates = [...feed, ...probeCandidates, ...probed];
+  let event = null;
+  try {
+    event = emitFriction(CHECKPOINT_PATTERN_ID, {
+      severity: 'low', surface, role: input.role || null, team: input.team, runtime: input.runtime,
+      detail: `checkpoint at ${surface}: surfaced ${candidates.length} candidate(s)`,
+    }, { file: input.incidentsPath, now: input.now });
+  } catch { event = null; } // best-effort observability; a failed emit must never block a build
+  return { surface, candidates, surfacedCount: candidates.length, event };
+}
+
+// Convenience for the builder seam: run the checkpoint only when explicitly enabled, swallowing all
+// errors so the deterministic build path is never affected.
+function maybeRunCheckpoint(input = {}) {
+  if (process.env.FLAW_CAPTURE_DISABLED === '1') return null; // Epic rollback no-op
+  try { return runCheckpoint(input); } catch { return null; }
+}
+
+module.exports = {
+  collectCandidates, runCheckpoint, maybeRunCheckpoint,
+  CHECKPOINT_PATTERN_ID, INCIDENTS_FILE,
+};

--- a/scripts/signer-alias.js
+++ b/scripts/signer-alias.js
@@ -1,0 +1,45 @@
+'use strict';
+const fs = require('fs');
+const path = require('path');
+
+function loadRegistry() {
+  const file = path.join(__dirname, '..', '..', 'inventory', 'team-model-signatures.json');
+  return JSON.parse(fs.readFileSync(file, 'utf8'));
+}
+
+// AC1/AC2: derive team from substrate (primary); falls back to modelPattern team
+function deriveTeamFromSubstrate(substrate, registry) {
+  if (!substrate) return null;
+  const map = registry.substrateTeamMap || {};
+  // strip device suffix (e.g. "github-copilot/penguin-1" → "github-copilot")
+  const base = String(substrate).toLowerCase().replace(/\/.*$/, '');
+  return map[base] || null;
+}
+
+function aliasSeed(registry, team, model) {
+  const t = (team || '').toLowerCase();
+  const m = (model || '').toLowerCase();
+  const match = (registry.registry || []).find(entry =>
+    (entry.team === '*' || entry.team === t) && new RegExp(entry.modelPattern, 'i').test(m));
+  return match?.aliasSeed || registry.defaultAliasSeed;
+}
+
+// AC3: substrate param added; substrate-first team resolution; backwards compatible
+function canonicalSignerAlias(teamName, role, model, registry = loadRegistry(), substrate = '') {
+  const effectiveTeam = deriveTeamFromSubstrate(substrate, registry) || (teamName || '').toLowerCase();
+  const roleKey = (role || 'collaborator').toLowerCase();
+  const seed = aliasSeed(registry, effectiveTeam, model);
+  const surname = registry.roleSurnames?.[roleKey] || registry.roleSurnames?.collaborator || 'Harper';
+  return `${seed} ${surname}`;
+}
+
+function enforceSignerAlias(teamName, role, input, opts = {}) {
+  const registry = opts.registry || loadRegistry();
+  const canonical = canonicalSignerAlias(teamName, role, opts.model || '', registry, opts.substrate || '');
+  const provided = String(input || '').trim();
+  if (!provided) return { ok: false, canonical, reason: 'missing-signed-by' };
+  const ok = provided.toLowerCase() === canonical.toLowerCase();
+  return { ok, canonical, provided, reason: ok ? 'match' : 'mismatch' };
+}
+
+module.exports = { enforceSignerAlias, canonicalSignerAlias, deriveTeamFromSubstrate };


### PR DESCRIPTION
## #2064 — End-to-end full baton-cycle fixture

Delivers the deferred AC5 of closed #1944: an end-to-end fixture exercising the full
**Manager → Collaborator → Admin → Consultant** baton cycle.

### What
- `scripts/baton-e2e.spec.js` — deterministic, offline E2E that drives the **real**
  `baton-comment-build.js` CLI through all four artifacts, asserts derived-signer
  independence (Mason/Harper/Reyes/Vale), validates full-cycle ordering via the real
  `baton-progression-parity.checkBatonProgression` (+ out-of-order & gap negatives),
  and terminal close via `label-lint-close-protection.decide` (+ reopen negative).
  13 assertions, exit-code signalled.
- `.github/workflows/validate-pr.yml` — new `validate-baton-e2e` CI job (AC5).
- Tracks the fixture's 12-file runtime dependency closure so CI runs on a clean checkout.
- The fixture self-provisions a minimal, **secret-free** signer registry (no cryptoKeys)
  when the out-of-repo registry is absent (CI), and never clobbers a real local one.

### Scope amendment (drift remediation)
AC1/AC4 rescoped from live-GitHub to a synthetic state machine (no live GitHub ticket
universe exists; matches the `cross-team-consult-e2e.js` precedent). Ratified by free
cross-family panels — review `766db29cb883d161`, merge-consensus `5ebd0c4c9629e694`
(both groq[meta]=PASS + mistral[mistral]=PASS).

### Governance note
`#2064` is a **local wiki-mirror** ticket (the real GitHub issue space maxes at #5), so this
PR intentionally does not use a `Closes #N` autolink. Baton artifacts live under
`wiki/work-log/ticket-2064/`. The untracked out-of-repo baton-tooling baseline that this PR
had to work around is captured as a follow-up self-annealing guardrail ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
