### PR TITLE
cleanup(#3801): correct #3026 misattribution — 39-file drift is live-harness baseline (capture, not discard)

### DIFF
--- a/wiki/work-log/tickets/3801.md
+++ b/wiki/work-log/tickets/3801.md
@@ -1,0 +1,114 @@
+---
+title: "#3801 cleanup: reconcile the 39-file live-harness baseline drift misattributed to #3026 (capture-as-baseline, never discard)"
+type: work-log
+content_trust_score: 0.9
+created: "2026-07-14"
+updated: "2026-07-14"
+tags: [issue, wiki-b, cleanup, drift-remediation]
+related: [3026, 3797, 2345, 3800, 2995, 3392, 3471]
+status: OPEN
+source_path: "github:issue/3801"
+source_sha256: local-mirror-pending-real-issue
+content_hash: local-mirror-pending-real-issue
+last_updated: "2026-07-14"
+generated_by_run: local
+---
+# #3801 — cleanup: reconcile the 39-file live-harness baseline drift (misattributed to #3026)
+
+> **Source**: local wiki-mirror (no live GitHub issue; real issue space maxes at #5) | **state: OPEN**
+> **Labels**: type:cleanup, status:backlog, priority:P1, area:governance, area:hooks, lane:code-change,
+> drift-remediation, owner:E3-baseline
+> **Cleanup claim**: `claim/cleanup-harness-baseline-drift` (own branch; NEVER absorbed into a feature ticket)
+
+## Trigger / provenance
+
+Operator flagged during the Drift-Remediation Roadmap execution (2026-07-14) that the working-tree
+edits sitting on the canonical checkout (`~/copilot-governance`, parked on
+`feat/3026-zero-miss-guardrails`) are **new drift since the roadmap's inception** and were not
+correctly characterised by roadmap step 4.i ("reconcile the ~39 stale #3026 working-tree edits").
+
+## Diagnosis (evidence-based — corrects the roadmap's #3026 attribution)
+
+The canonical checkout carried **39 modified tracked files** (+2159 / −607) plus 724 untracked
+(untracked = normal mirror state, see [[git-baseline-restore-3797]]). Investigation:
+
+1. **NOT #3026.** #3026's real commit `a15fe38` added **11 NEW files** (zero-miss guardrail scripts +
+   hooks + tests). The 39 modified files have **zero overlap** with `a15fe38`
+   (`comm -12 <(git show --name-only a15fe38) <(git diff --name-only)` → empty). They merely
+   co-reside on the feat/3026 checkout.
+2. **Multi-ticket accumulation.** The added lines reference **25+ distinct tickets** — top: #3392(10),
+   #3569(7), #3266(5), #2995(5), #3471(4), #2517(4), #2148(4), #1828(4), #3403, #3053, #2355 … This is
+   dozens of tickets' worth of harness evolution, not one ticket's scope.
+3. **On no branch.** The diff is byte-identical vs `origin/main`, `origin/feat/2345-…`, and
+   `origin/feat/3800-…` (same 793/420-line deltas), so the edits live ONLY in the canonical
+   working tree — never committed anywhere.
+4. **Coherent, valuable, live.** Spot check of `hooks/scripts/pretool_guard.py` (+793) shows
+   intentional, fail-closed guard logic (shell write-target detection #2995/#3001/#3471,
+   hook-mutation/sensitive-path adjudicators #3392/#3403, IT-ops bypass detector #2142,
+   one-ticket-per-worktree, blast-radius caps, session-anomaly gate). This is the **actually-running
+   harness**. `git reset --hard`/discard would **silently revert live security guards** — the
+   roadmap's "discard per owner" wording is therefore actively dangerous for this set.
+
+**Root class:** long-standing gap where merged/closed tickets evolved the live install (hooks,
+instructions, skills, agents) but never committed the change back to a tracked branch → the committed
+baseline (`origin/main`) drifted far behind the running harness. This is exactly the drift the
+roadmap exists to fix; it is **E3-baseline-owned** (E3 owns baseline tracking).
+
+## Affected surface (39 files)
+
+- `hooks/scripts/`: `pretool_guard.py`(+793), `stop_reminder.py`, `posttool_reminders.py`, `session_context.py`
+- `instructions/`: `role-baton-routing`(+420), `global-standards`, `workflow-resilience`,
+  `github-governance`, `operator-identity-context`, `release-docs-hygiene`, `repo-health-onboarding`, +2
+- `skills/`: 20 SKILL.md (role-*, github-*, repo-*, operator-identity, workflow-self-anneal, mem-watchdog …)
+- `agents/`: governance-auditor, planner, release-reviewer, security-scanner
+- `.gitignore` (+25)
+
+## Acceptance criteria (research-first; execute under the cleanup claim, NOT bundled)
+
+- [ ] AC1 (safety-first): NO destructive discard. The live-harness edits are captured, not reverted.
+      Before any `reset`, snapshot the 39-file diff to `wiki/work-log/ticket-3801/harness-drift.patch`.
+- [ ] AC2 (attribution pass): classify each of the 39 files' hunks as (a) **capture** — coherent
+      evolution traceable to a merged/closed ticket, adopt as new baseline; (b) **hold** — references
+      an OPEN ticket whose owner branch should carry it, route there; (c) **discard** — proven
+      experimental/abandoned. Record the per-file disposition table.
+- [ ] AC3 (baseline capture): commit the (a)-class hunks to `main` via
+      `claim/cleanup-harness-baseline-drift` → PR → CI-green → merge, so `origin/main` == running
+      harness for those files. Depends on and must not conflict with E3 baseline work (#3797).
+- [ ] AC4 (dirty-checkout restoration): after capture, the canonical checkout's `git status` for the
+      captured files is clean (no residual working-tree drift), and the #3026 branch retains ONLY its
+      own 11-file deliverable.
+- [ ] AC5 (recurrence guard): a wired check that flags when the live install diverges from the
+      committed baseline beyond a threshold (advisory-first), so this never re-accumulates silently.
+      Candidate: extend the E1 telemetry / a `baseline-drift-sentinel` under `scripts/`.
+- [ ] AC6 (consensus): capture-vs-discard taxonomy + the AC5 sentinel design ratified by a free
+      ≥2-distinct-family cross-model panel (`cross-family-consensus.js`); receipt recorded.
+
+## Non-goals / constraints
+
+- Do NOT bundle any of these 39 files into a feature ticket (incl. #1893 or #3026). One cleanup claim.
+- Do NOT commit foreign files from inside the #3026 (or any feature) worktree.
+- Never touch another session's live worktree/branch/claim.
+- Genuine carve-out: none — capture→PR→merge to UNPROTECTED main is reversible ⇒ complete autonomously.
+
+## Roadmap integration (bundled remediation)
+
+Supersedes/replaces roadmap **step 4.i** wording. Corrected instruction:
+> "The ~39 modified tracked files on the feat/3026 checkout are NOT #3026 edits — they are
+> multi-ticket **live-harness baseline drift** (E3-owned). Do NOT discard. Reconcile them under
+> cleanup claim `claim/cleanup-harness-baseline-drift` (#3801): snapshot → attribute → capture-as-
+> baseline via PR → verify clean. #3026's own 11-file deliverable (`a15fe38`) is separate and merges
+> on its own branch."
+
+Tier: unblocked NOW (Tier-A / E3 cleanup). Pickable by any session via the cleanup-claim race.
+
+## Manager scope (baton entry contract)
+
+- **Deliverable**: this analysis + corrected roadmap instruction filed as a tracked mirror ticket on
+  branch `claim/cleanup-harness-baseline-drift` and pushed to origin; MEMORY protective note added so
+  every parallel session sees the "do-not-discard" truth before acting on old step 4.i.
+- **Out of scope for THIS baton pass** (deferred to a follow-on execution pass under this same claim):
+  the full 39-file attribution + capture PR (AC2–AC6). Operator directive was "bundle the remediation
+  into the plan, then return to #1893" — so this pass FILES + PROTECTS; execution is a claimable
+  follow-on.
+- **Verification gate**: ticket file present on the branch; branch + claim ref pushed to origin;
+  MEMORY.md pointer added; no edit to any file outside `wiki/work-log/tickets/3801.md`.


### PR DESCRIPTION
## Ticket
Mirror: `wiki/work-log/tickets/3801.md` (#3801 is wiki-mirror — no live `Closes #N`).

## What / why
Operator flagged the working-tree edits on the `feat/3026` canonical checkout as **new drift** mis-scoped by roadmap step 4.i. This PR **files the analysis + corrected remediation** durably on main (execution of the 39-file capture is a tracked follow-on under the same claim).

**Finding (evidence in ticket):** the 39 modified tracked files are **NOT #3026 edits** (zero overlap with `a15fe38`); they span **25+ tickets**, live on **no branch**, and are **coherent running security-guard logic** (`pretool_guard.py` +793 etc.). The roadmap's "discard per owner" wording is dangerous — a `reset --hard` would silently revert live guards.

**Corrected step 4.i:** capture-as-baseline → snapshot → attribute per-file → PR → verify clean. **Never discard.** E3-baseline-owned.

## Scope
Doc-only (ticket file). Does NOT commit or touch the 39-file drift itself (separate execution pass). Reversible; unprotected main ⇒ autonomous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)