### PR TITLE
fix(#3799-AC1): hermetic signer-alias registry resolution

### DIFF
--- a/inventory/harness-self-test-registry.json
+++ b/inventory/harness-self-test-registry.json
@@ -4,6 +4,7 @@
   "validators": [
     { "name": "validator-discipline", "spec": "scripts/validator-discipline.spec.js" },
     { "name": "epic-child-baton-traceability", "spec": "scripts/epic-child-baton-traceability.spec.js" },
-    { "name": "accountable-team", "spec": "scripts/accountable-team.spec.js" }
+    { "name": "accountable-team", "spec": "scripts/accountable-team.spec.js" },
+    { "name": "signer-alias", "spec": "scripts/signer-alias.spec.js" }
   ]
 }

--- a/inventory/team-model-signatures.json
+++ b/inventory/team-model-signatures.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "team-model-signatures/alias-subset-v1",
+  "_provenance": "In-repo, SECRET-FREE alias-resolution subset of the canonical team-model-signatures registry (#3799-AC1). Tracked so scripts/signer-alias.js resolves from a clean, .git-less archive checkout (hermetic baton tooling). Contains ONLY the fields signer-alias needs to derive a canonical alias — defaultAliasSeed, roleSurnames, substrateTeamMap, registry. It DELIBERATELY OMITS cryptoKeys and any signing material; the full registry with public keys stays out-of-repo at <repo>/../inventory/team-model-signatures.json and is preferred via BATON_SIGNER_REGISTRY / legacy path when present. Keep alias values in sync with the canonical registry when seeds change.",
+  "lastUpdated": "2026-07-14",
+  "defaultAliasSeed": "Nova",
+  "roleSurnames": {
+    "manager": "Mason",
+    "collaborator": "Harper",
+    "admin": "Reyes",
+    "consultant": "Vale",
+    "claude-code-team-manager-noting-overlap": "Mason"
+  },
+  "substrateTeamMap": {
+    "github-copilot": "copilot",
+    "codex-cli": "codex",
+    "codex-vscode-ide": "codex",
+    "claude-code-cli": "claude-code",
+    "openclaw-gateway": "openclaw",
+    "google": "antigravity",
+    "cursor-ide": "cursor"
+  },
+  "registry": [
+    { "team": "cursor", "modelPattern": ".*", "aliasSeed": "Cyrus" },
+    { "team": "codex", "modelPattern": "^gpt-5\\.4$", "aliasSeed": "Quill" },
+    { "team": "codex", "modelPattern": "gpt-5.*codex", "aliasSeed": "Caden" },
+    { "team": "copilot", "modelPattern": "^claude-[34]", "aliasSeed": "Soren" },
+    { "team": "copilot", "modelPattern": "sonnet", "aliasSeed": "Soren" },
+    { "team": "copilot", "modelPattern": "opus", "aliasSeed": "Orion" },
+    { "team": "copilot", "modelPattern": "gpt-5.*mini", "aliasSeed": "Milo" },
+    { "team": "copilot", "modelPattern": "gpt-5.*codex", "aliasSeed": "Coda" },
+    { "team": "copilot", "modelPattern": "gpt-5", "aliasSeed": "Gideon" },
+    { "team": "copilot", "modelPattern": "gpt-4", "aliasSeed": "Gage" },
+    { "team": "copilot", "modelPattern": "^o[0-9]", "aliasSeed": "Odell" },
+    { "team": "copilot", "modelPattern": "qwen", "aliasSeed": "Quenby" },
+    { "team": "copilot", "modelPattern": "gemini", "aliasSeed": "Gale" },
+    { "team": "copilot", "modelPattern": "mistral", "aliasSeed": "Marlow" },
+    { "team": "claude-code", "modelPattern": "sonnet", "aliasSeed": "Clio" },
+    { "team": "claude-code", "modelPattern": "opus", "aliasSeed": "Orla" },
+    { "team": "openclaw", "modelPattern": "qwen", "aliasSeed": "Quinn", "devicePattern": "^windows-laptop$" },
+    { "team": "openclaw", "modelPattern": "mistral", "aliasSeed": "Mira", "devicePattern": "^windows-laptop$" },
+    { "team": "openclaw", "modelPattern": "phi", "aliasSeed": "Fia", "devicePattern": "^windows-laptop$" },
+    { "team": "antigravity", "modelPattern": "gemini", "aliasSeed": "Apollo" },
+    { "team": "antigravity", "modelPattern": "claude-sonnet", "aliasSeed": "Aria" },
+    { "team": "antigravity", "modelPattern": "claude-opus", "aliasSeed": "Axel" },
+    { "team": "antigravity", "modelPattern": "claude-haiku", "aliasSeed": "Aiden" },
+    { "team": "*", "modelPattern": "qwen", "aliasSeed": "Quinn" },
+    { "team": "*", "modelPattern": "mistral", "aliasSeed": "Mira" },
+    { "team": "*", "modelPattern": "phi", "aliasSeed": "Fia" },
+    { "team": "*", "modelPattern": "gemma", "aliasSeed": "Gemma" }
+  ]
+}

--- a/scripts/baton-e2e.spec.js
+++ b/scripts/baton-e2e.spec.js
@@ -36,13 +36,14 @@ const TEAM_MODEL = 'claude-code:opus@anthropic';
 const TICKET = 2064;
 
 // --- Signer-registry provisioning (offline/CI self-containment) ----------------------
-// signer-alias.js loads its registry from <repo>/../inventory/team-model-signatures.json
-// — an OUT-OF-REPO path that is absent on a clean CI checkout (documented drift; see the
-// #2064 self-anneal follow-up). To keep this fixture hermetic we provision a MINIMAL,
-// secret-free registry (roleSurnames + seed only — NO cryptoKeys) at that exact path,
-// but ONLY when it is missing, and we remove ONLY what we created so a real local
-// registry is never clobbered.
-const REGISTRY_PATH = path.join(__dirname, '..', '..', 'inventory', 'team-model-signatures.json');
+// #3799-AC1: signer-alias.js now resolves its registry hermetically, preferring the
+// in-repo, tracked, secret-free alias subset at <repo>/inventory/team-model-signatures.json.
+// That tracked file ships on the branch, so on a clean archive checkout it already exists
+// and provisionRegistry() is a no-op (it only writes when the path is missing, and removes
+// ONLY what it created). The prior workaround wrote a fixture to the OUT-OF-REPO
+// <repo>/../inventory path; that patch is no longer needed now that the dependency closure
+// is tracked in-repo.
+const REGISTRY_PATH = path.join(__dirname, '..', 'inventory', 'team-model-signatures.json');
 const FIXTURE_REGISTRY = {
   defaultAliasSeed: 'Nova',
   roleSurnames: { manager: 'Mason', collaborator: 'Harper', admin: 'Reyes', consultant: 'Vale' },

--- a/scripts/signer-alias.js
+++ b/scripts/signer-alias.js
@@ -2,9 +2,31 @@
 const fs = require('fs');
 const path = require('path');
 
+// #3799-AC1 (hermetic baton tooling): resolve the team-model-signature registry so signer-alias
+// runs from a clean, .git-less archive checkout. Resolution order (first existing wins):
+//   1. BATON_SIGNER_REGISTRY env override (explicit path — CI / tests / operator control).
+//   2. In-repo, tracked, secret-free alias subset: <repo>/inventory/team-model-signatures.json.
+//   3. Legacy out-of-repo full registry: <repo>/../inventory/team-model-signatures.json (back-compat
+//      with existing local dev machines that hold the cryptoKey-bearing canonical registry).
+// If none resolves, throw a clear, actionable error instead of an opaque ENOENT.
+const IN_REPO_REGISTRY = path.join(__dirname, '..', 'inventory', 'team-model-signatures.json');
+const LEGACY_REGISTRY = path.join(__dirname, '..', '..', 'inventory', 'team-model-signatures.json');
+
+function registryPath() {
+  const env = process.env.BATON_SIGNER_REGISTRY;
+  const candidates = [env, IN_REPO_REGISTRY, LEGACY_REGISTRY].filter(Boolean);
+  for (const c of candidates) {
+    if (fs.existsSync(c)) return c;
+  }
+  throw new Error(
+    `signer-alias: no team-model-signatures registry found. Looked at ` +
+      `${candidates.join(', ')}. Set BATON_SIGNER_REGISTRY or ensure the in-repo ` +
+      `inventory/team-model-signatures.json is present.`,
+  );
+}
+
 function loadRegistry() {
-  const file = path.join(__dirname, '..', '..', 'inventory', 'team-model-signatures.json');
-  return JSON.parse(fs.readFileSync(file, 'utf8'));
+  return JSON.parse(fs.readFileSync(registryPath(), 'utf8'));
 }
 
 // AC1/AC2: derive team from substrate (primary); falls back to modelPattern team
@@ -42,4 +64,12 @@ function enforceSignerAlias(teamName, role, input, opts = {}) {
   return { ok, canonical, provided, reason: ok ? 'match' : 'mismatch' };
 }
 
-module.exports = { enforceSignerAlias, canonicalSignerAlias, deriveTeamFromSubstrate };
+module.exports = {
+  enforceSignerAlias,
+  canonicalSignerAlias,
+  deriveTeamFromSubstrate,
+  loadRegistry,
+  registryPath,
+  IN_REPO_REGISTRY,
+  LEGACY_REGISTRY,
+};

--- a/scripts/signer-alias.spec.js
+++ b/scripts/signer-alias.spec.js
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+'use strict';
+
+// signer-alias.spec.js — #3799-AC1 (hermetic baton tooling).
+// Proves scripts/signer-alias.js resolves its registry from a CLEAN, .git-less archive
+// checkout: the in-repo, tracked, secret-free alias subset at
+// <repo>/inventory/team-model-signatures.json must be found with NO out-of-repo
+// ../inventory present. Also pins the resolution-order precedence (env override >
+// in-repo > legacy out-of-repo) and the canonical-alias / enforce behavior.
+//
+// Deterministic, offline, no network, no clock/random. Node built-in assert only.
+// Run:  node scripts/signer-alias.spec.js   (exit 0 = pass, 1 = any failure)
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const sa = require('./signer-alias.js');
+const {
+  canonicalSignerAlias,
+  enforceSignerAlias,
+  deriveTeamFromSubstrate,
+  loadRegistry,
+  registryPath,
+  IN_REPO_REGISTRY,
+} = sa;
+
+let failures = 0;
+function test(name, fn) {
+  try { fn(); console.log('  PASS ' + name); }
+  catch (e) { failures++; console.error('  FAIL ' + name + ': ' + (e && e.message)); }
+}
+
+// --- Hermeticity: the in-repo registry exists and is the default resolution ---------
+test('in-repo registry is tracked and present', () => {
+  assert.ok(fs.existsSync(IN_REPO_REGISTRY), `missing in-repo registry ${IN_REPO_REGISTRY}`);
+});
+
+test('default resolution (no env) points at the in-repo registry', () => {
+  const saved = process.env.BATON_SIGNER_REGISTRY;
+  delete process.env.BATON_SIGNER_REGISTRY;
+  try {
+    // On a clean archive there is no <repo>/../inventory, so the in-repo path must win.
+    // If a legacy out-of-repo registry happens to exist on a dev machine it is NOT the
+    // in-repo path; we only assert the in-repo path is chosen when it is the first that
+    // exists — which it always is here because in-repo precedes legacy in the order.
+    assert.equal(registryPath(), IN_REPO_REGISTRY);
+  } finally {
+    if (saved === undefined) delete process.env.BATON_SIGNER_REGISTRY;
+    else process.env.BATON_SIGNER_REGISTRY = saved;
+  }
+});
+
+test('in-repo registry is SECRET-FREE (no cryptoKeys / private key material)', () => {
+  const raw = fs.readFileSync(IN_REPO_REGISTRY, 'utf8');
+  const reg = JSON.parse(raw);
+  assert.ok(!('cryptoKeys' in reg), 'in-repo registry must not carry cryptoKeys');
+  assert.ok(!/PRIVATE KEY/i.test(raw), 'in-repo registry must not contain private key material');
+});
+
+test('loadRegistry() parses the in-repo subset with required alias fields', () => {
+  const reg = loadRegistry();
+  assert.ok(reg.defaultAliasSeed, 'defaultAliasSeed');
+  assert.ok(reg.roleSurnames && reg.roleSurnames.manager, 'roleSurnames.manager');
+  assert.ok(Array.isArray(reg.registry) && reg.registry.length > 0, 'registry[]');
+});
+
+// --- Resolution-order precedence: env override wins ---------------------------------
+test('BATON_SIGNER_REGISTRY env override takes precedence', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'signer-alias-'));
+  const override = path.join(tmp, 'custom.json');
+  fs.writeFileSync(override, JSON.stringify({
+    defaultAliasSeed: 'Zeta',
+    roleSurnames: { manager: 'Zed' },
+    substrateTeamMap: {},
+    registry: [{ team: '*', modelPattern: '.*', aliasSeed: 'Zeta' }],
+  }));
+  const saved = process.env.BATON_SIGNER_REGISTRY;
+  process.env.BATON_SIGNER_REGISTRY = override;
+  try {
+    assert.equal(registryPath(), override);
+    assert.equal(canonicalSignerAlias('anyteam', 'manager', 'any-model'), 'Zeta Zed');
+  } finally {
+    if (saved === undefined) delete process.env.BATON_SIGNER_REGISTRY;
+    else process.env.BATON_SIGNER_REGISTRY = saved;
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('a non-existent env override is skipped, falling back to in-repo', () => {
+  const saved = process.env.BATON_SIGNER_REGISTRY;
+  process.env.BATON_SIGNER_REGISTRY = '/nonexistent/path/does-not-exist.json';
+  try {
+    assert.equal(registryPath(), IN_REPO_REGISTRY);
+  } finally {
+    if (saved === undefined) delete process.env.BATON_SIGNER_REGISTRY;
+    else process.env.BATON_SIGNER_REGISTRY = saved;
+  }
+});
+
+// --- Alias derivation behavior (regression pins against the in-repo subset) ----------
+test('substrate-first team derivation', () => {
+  const reg = loadRegistry();
+  assert.equal(deriveTeamFromSubstrate('github-copilot/penguin-1', reg), 'copilot');
+  assert.equal(deriveTeamFromSubstrate('claude-code-cli', reg), 'claude-code');
+  assert.equal(deriveTeamFromSubstrate('unknown-substrate', reg), null);
+});
+
+test('canonical alias resolves team+model+role deterministically', () => {
+  // claude-code + opus + admin -> aliasSeed "Orla" + roleSurname "Reyes"
+  assert.equal(canonicalSignerAlias('claude-code', 'admin', 'opus'), 'Orla Reyes');
+  // copilot + opus + manager -> "Orion" + "Mason"
+  assert.equal(canonicalSignerAlias('copilot', 'manager', 'opus'), 'Orion Mason');
+  // substrate overrides teamName: substrate github-copilot -> copilot team
+  assert.equal(canonicalSignerAlias('ignored', 'collaborator', 'opus', loadRegistry(), 'github-copilot'), 'Orion Harper');
+});
+
+test('enforceSignerAlias match / mismatch / missing', () => {
+  const ok = enforceSignerAlias('claude-code', 'admin', 'Orla Reyes', { model: 'opus' });
+  assert.equal(ok.ok, true);
+  assert.equal(ok.reason, 'match');
+  const bad = enforceSignerAlias('claude-code', 'admin', 'Wrong Name', { model: 'opus' });
+  assert.equal(bad.ok, false);
+  assert.equal(bad.reason, 'mismatch');
+  const missing = enforceSignerAlias('claude-code', 'admin', '', { model: 'opus' });
+  assert.equal(missing.ok, false);
+  assert.equal(missing.reason, 'missing-signed-by');
+});
+
+if (failures) {
+  console.error(`signer-alias.spec: ${failures} failure(s)`);
+  process.exit(1);
+}
+console.log('signer-alias.spec: OK');
+process.exit(0);

--- a/wiki/work-log/ticket-3799/admin.md
+++ b/wiki/work-log/ticket-3799/admin.md
@@ -1,0 +1,26 @@
+---
+title: "#3799-AC1 Admin — push / PR / CI / merge"
+type: baton-artifact
+role: admin
+ticket: 3799
+ac: AC1
+created: "2026-07-14"
+pr: 11
+---
+
+# #3799-AC1 — Admin handoff
+
+**Team & Model**: claude-code:opus@anthropic · **Signed-by**: Orla Reyes · **Role**: admin
+
+## Actions
+- Branch `feat/3799-ac1-hermetic-signer` pushed to origin.
+- **PR #11** opened → base `main` (unprotected mirror). Body cites mirror path
+  `wiki/work-log/tickets/3799.md` (mirror-mode; no `Closes #N`).
+- CI: repo push/PR checks (global-governance-presence) + hermetic archive proof recorded in the PR.
+- Merge to unprotected `main` = **reversible** → completed autonomously (G8; see Consultant closeout).
+
+## Merge record
+- Method: squash merge to `main`.
+- Post-merge: release `claim/3799`, prune `feat/3799-ac1-hermetic-signer`, `git worktree remove`.
+
+(Merge SHA appended on completion below.)

--- a/wiki/work-log/ticket-3799/collaborator.md
+++ b/wiki/work-log/ticket-3799/collaborator.md
@@ -1,0 +1,36 @@
+---
+title: "#3799-AC1 Collaborator — hermetic signer-alias implementation + evidence"
+type: baton-artifact
+role: collaborator
+ticket: 3799
+ac: AC1
+created: "2026-07-14"
+---
+
+# #3799-AC1 — Collaborator handoff
+
+**Team & Model**: claude-code:opus@anthropic · **Signed-by**: Orla Harper · **Role**: collaborator
+
+## Changes (only AC1 files)
+- `scripts/signer-alias.js` — `loadRegistry()` → `registryPath()` resolution order:
+  `BATON_SIGNER_REGISTRY` env → in-repo `inventory/team-model-signatures.json` → legacy out-of-repo
+  `<repo>/../inventory/...` → clear throw. Exported `loadRegistry/registryPath/IN_REPO_REGISTRY/LEGACY_REGISTRY`.
+- `inventory/team-model-signatures.json` — NEW tracked, secret-free alias subset (defaultAliasSeed,
+  roleSurnames, substrateTeamMap, registry). No `cryptoKeys`, no `PRIVATE KEY` material.
+- `scripts/signer-alias.spec.js` — NEW hermetic regression (9 tests).
+- `scripts/baton-e2e.spec.js` — `REGISTRY_PATH` now in-repo; no out-of-repo fixture write.
+- `inventory/harness-self-test-registry.json` — registered `signer-alias`.
+
+## Validation evidence (matches Manager gates)
+- **G-hermetic** — `git archive feat/3799-ac1-hermetic-signer | tar -x -C /tmp/ci-3799` (clean, no
+  `.git`, no `/tmp/inventory` sibling), then in `/tmp/ci-3799` with `BATON_SIGNER_REGISTRY` unset:
+  - `node scripts/signer-alias.spec.js` → **exit 0** (9/9 PASS, incl. secret-free invariant)
+  - `node scripts/baton-e2e.spec.js` → **exit 0** (13/13 PASS, signer-independence intact)
+  - `node scripts/validator-discipline.spec.js` → **exit 0**
+- **G-discipline** — `validator-discipline.js --files=<changeset>` → `OK — no unguarded validators`.
+- Local (pre-archive) runs of all three specs also green.
+
+Behavior preserved for existing dev machines (in-repo alias values mirror the canonical registry; the
+out-of-repo cryptoKey-bearing registry remains reachable via env / legacy path).
+
+→ Handing to **Admin** for push/PR/CI/merge.

--- a/wiki/work-log/ticket-3799/consultant.md
+++ b/wiki/work-log/ticket-3799/consultant.md
@@ -1,0 +1,39 @@
+---
+title: "#3799-AC1 Consultant closeout — independent critique + cross-family receipt"
+type: baton-artifact
+role: consultant
+ticket: 3799
+ac: AC1
+created: "2026-07-14"
+cross_family_receipt: "35d7328999ec3357"
+---
+
+# #3799-AC1 — Consultant CLOSEOUT
+
+**Team & Model**: claude-code:opus@anthropic · **Signed-by**: Orla Vale · **Role**: consultant
+
+## Independent cross-family ratification (AC5 slice for the hermetic-path design)
+`node scripts/cross-family-consensus.js --ticket 3799 --kind review` →
+**consensus: PASS**, **receipt `35d7328999ec3357`**, panel = groq[meta]=PASS + mistral[mistral]=PASS
+(2 distinct non-Anthropic families; cerebras/gemini empty_response, not counted). Ratifies (a) the
+env → in-repo → legacy resolution design and (b) keeping the in-repo fallback secret-free.
+
+## Risk assessment
+- **Correctness**: resolution order is total and terminates in a clear throw; existing dev machines
+  keep prior behavior (in-repo alias values mirror the canonical registry; cryptoKey registry stays
+  reachable via env/legacy). LOW.
+- **Security (G4)**: in-repo file is asserted secret-free by a spec test (`!cryptoKeys` + no
+  `PRIVATE KEY`). No signing material enters the repo. LOW.
+- **Hermeticity (G6)**: verified by archive run on a clean, `.git`-less tree with no `../inventory`
+  sibling — both `signer-alias.spec.js` and `baton-e2e.spec.js` exit 0. This is the deliverable's core
+  proof and it holds. LOW.
+- **Scope**: AC1 only. AC2/AC3/AC4 remain OPEN and tier-blocked; ticket stays OPEN. No carve-out
+  weakened. Merge to unprotected mirror `main` is reversible → completed autonomously (G8).
+
+## Autonomy-vs-escalate decision (G8)
+Reversible path (feature-branch push + PR + merge to **unprotected** mirror `main`) → completed
+autonomously per #3799 AC2 principle. No retained carve-out triggered (not protected-main, not
+irreversible, not security-weakening — the change removes signing material from the repo, it does not
+add it).
+
+**Verdict: RELEASE.** AC1 complete and independently ratified.

--- a/wiki/work-log/ticket-3799/manager-scope.md
+++ b/wiki/work-log/ticket-3799/manager-scope.md
@@ -1,0 +1,64 @@
+---
+title: "#3799-AC1 Manager scope — hermetic signer-alias registry resolution"
+type: baton-artifact
+role: manager
+ticket: 3799
+ac: AC1
+created: "2026-07-14"
+status: OPEN
+---
+
+# #3799-AC1 — Manager scope (hermetic baton tooling)
+
+> Baton: **Manager** → Collaborator → Admin → Consultant. Single branch
+> `feat/3799-ac1-hermetic-signer`, single worktree `~/wt-3799`, one PR.
+> Partial-ticket delivery: this branch closes **AC1 only**. AC2/AC3/AC4/AC5 remain
+> OPEN (tier-blocked). Ticket status stays OPEN; only the AC1 checkbox flips.
+
+## Problem (root cause #1 & #2 of #3799)
+
+`scripts/signer-alias.js` `loadRegistry()` resolves the team-model-signature registry from
+`path.join(__dirname, '..', '..', 'inventory', 'team-model-signatures.json')` — an **out-of-repo**
+path (`<repo>/../inventory/...`) that is **absent on a clean, `.git`-less archive checkout**. Any
+baton tooling that resolves a signer alias therefore cannot run from a bare checkout → cannot pass
+hermetic CI → normalizes "complete at mirror-level, defer merge" (the exact friction #3799 anneals).
+`scripts/baton-e2e.spec.js` works around this by self-provisioning a fixture at the out-of-repo
+path — a patch, not a fix.
+
+## Scope (AC1 only)
+
+Make signer-alias registry resolution **hermetic** so baton tooling runs from a clean checkout,
+and **track the registry closure in-repo**.
+
+### Deliverables
+1. `scripts/signer-alias.js` — `loadRegistry()` resolution order:
+   `BATON_SIGNER_REGISTRY` env override → in-repo `<repo>/inventory/team-model-signatures.json`
+   → legacy out-of-repo `<repo>/../inventory/...` (back-compat) → clear throw. Behavior for existing
+   local dev machines is preserved (in-repo alias subset mirrors the real registry's alias values).
+2. `inventory/team-model-signatures.json` (NEW, tracked in-repo) — **secret-free** alias-resolution
+   subset: `defaultAliasSeed`, `roleSurnames`, `substrateTeamMap`, `registry`. **NO `cryptoKeys`**
+   (public keys stay out-of-repo; nothing secret enters the repo — G4).
+3. `scripts/signer-alias.spec.js` (NEW) — hermetic regression: resolution-order precedence,
+   `canonicalSignerAlias`, `enforceSignerAlias` match/mismatch. Node built-in `assert`, self-executing,
+   exit 1 on fail.
+4. `scripts/baton-e2e.spec.js` — resolve the signer registry from the in-repo path so the E2E is
+   hermetic without writing to an out-of-repo location.
+5. `inventory/harness-self-test-registry.json` — register `signer-alias` (regression discipline #1893).
+
+## Acceptance gates (verification)
+- G-hermetic: `git archive feat/3799-ac1-hermetic-signer | tar -x -C /tmp/ci-3799` then
+  `(cd /tmp/ci-3799 && node scripts/signer-alias.spec.js && node scripts/baton-e2e.spec.js)` → exit 0
+  on a clean, `.git`-less, no-`../inventory` tree.
+- G-consensus (AC5 slice for the hermetic-path design): `cross-family-consensus.js --ticket 3799
+  --kind review`, ≥2 distinct families, PASS; receipt cited in the Consultant artifact.
+- G-discipline: `node scripts/validator-discipline.js --files=...` clean (signer-alias allowlisted;
+  spec+registry shipped regardless).
+
+## Non-goals
+- AC2 (reversible/carve-out classifier), AC3 (mirror Admin semantics), AC4 (completion-gate hardening)
+  — separate tier-blocked units. Do not weaken carve-outs or C-G1/C-G4.
+
+## Constraints
+- Touch ONLY AC1 files. main is an unprotected mirror → feature-branch push + PR + merge is
+  reversible → complete autonomously (G8 autonomy default). Mirror ticket: PR body cites
+  `wiki/work-log/tickets/3799.md`; no `Closes #N`.

--- a/wiki/work-log/tickets/3799.md
+++ b/wiki/work-log/tickets/3799.md
@@ -1,0 +1,92 @@
+---
+title: "#3799 anneal: enforce full Agile role-workflow completion as the default (hermetic baton tooling + reversible-vs-carveout autonomy classifier + mirror-ticket Admin semantics)"
+type: work-log
+content_trust_score: 0.6
+created: "2026-07-14"
+updated: "2026-07-14"
+tags: [issue, wiki-b, anneal]
+related: [2064, 3025, 3026, 3797, 3798]
+status: OPEN
+source_path: "github:issue/3799"
+source_sha256: "local-mirror-pending-real-issue"
+content_hash: "local-mirror-pending-real-issue"
+last_updated: "2026-07-14"
+generated_by_run: local
+---
+# #3799 — anneal: enforce full Agile role-workflow completion as the default
+
+> **Source**: local wiki-mirror (no live GitHub issue; real issue space maxes at #5) | **state: OPEN**
+> **Labels**: type:anneal, status:backlog, priority:P2, area:governance, area:scripts, lane:code-change
+
+## Trigger / provenance
+
+Filed from the #2064 execution post-mortem. While completing #2064 (full
+Manager→Collaborator→Admin→Consultant baton-cycle E2E fixture), the agent initially **stopped at
+"mirror-level" and escalated the Admin push/PR/merge to the operator** instead of completing the
+whole Agile role workflow autonomously. The operator corrected this: reversible completion should be
+the enforced default, and the friction that caused the premature stop should be self-annealed.
+(#2064 was then completed end-to-end: PR #6, squash `90834541`, CI green.)
+
+## Diagnosed friction / drift (root causes)
+
+1. **Untracked, out-of-repo baton-tooling baseline.** The baton tooling (`baton-comment-build.js`
+   and its 12-file runtime closure) was untracked working-tree state; the signer registry lives at
+   `<repo>/../inventory/team-model-signatures.json` — *outside the repo root*. Any ticket depending
+   on it looks un-CI-able, so "complete at mirror-level, defer merge" became the silent default and
+   normalized **incomplete Admin batons**. (See [[git-baseline-restore-3797]].)
+2. **Non-hermetic `signer-alias.js`.** `loadRegistry()` resolves `path.join(__dirname,'..','..',
+   'inventory',...)` — an out-of-repo path absent on a clean checkout. Tooling that can't run from a
+   bare checkout can't pass CI, reinforcing (1). (#2064 worked around this by self-provisioning a
+   minimal secret-free registry inside the fixture — a patch, not a fix.)
+3. **Mirror/real ticket-space disconnect.** The `#1148-#3799` ticket universe is a local wiki mirror;
+   the real GitHub remote tops out at issue #5. Admin gates keyed to a *live* issue (`Closes #N`,
+   `gh issue close N`, status/role-label transitions on a real issue) structurally cannot fire for
+   mirror tickets, so the workflow degrades to local artifacts. (See
+   [[ticket-universe-is-local-mirror-no-github]].)
+4. **Autonomy default mis-calibrated at the merge boundary.** The agent generalized the correct rule
+   "never commit to local `main` (read-only mirror)" into "never complete the Admin baton," treating
+   *all* push/PR/merge as a blanket human carve-out — even though `main` was **unprotected**, a
+   feature-branch push + PR is **reversible**, and the task authorized autonomous completion. The
+   genuine carve-out is *merge to a protected/production main*, not the reversible steps before it.
+
+## Acceptance criteria (research-first; Phase-0 scopes AC1-AC5 before build)
+
+- [x] AC1 (hermetic tooling): `signer-alias` (and any other out-of-repo baton dependency) resolves
+      its registry from an **in-repo** path (repo-root `inventory/`) or an env override with a tracked
+      in-repo fallback fixture, so baton tooling runs from a clean checkout. Track the baton-tooling
+      dependency closure on `main`. Regression: a clean-tree archive run of a baton E2E is green.
+      **DONE 2026-07-14** (branch `feat/3799-ac1-hermetic-signer`): `loadRegistry()` resolves
+      `BATON_SIGNER_REGISTRY` env → in-repo `inventory/team-model-signatures.json` (tracked,
+      secret-free alias subset, NO cryptoKeys) → legacy out-of-repo → clear throw; sibling spec
+      `scripts/signer-alias.spec.js` + self-test registry entry; `baton-e2e.spec.js` resolves in-repo.
+      Hermetic archive run (clean `.git`-less tree, no `../inventory`) of `signer-alias.spec` +
+      `baton-e2e.spec` green. Cross-family consensus PASS, receipt `35d7328999ec3357`
+      (groq[meta] + mistral[mistral]). Artifacts: `wiki/work-log/ticket-3799/`.
+- [ ] AC2 (reversible-vs-carveout classifier): a predicate/guardrail that classifies remaining Admin
+      steps as **reversible** (feature-branch push + PR on unprotected/mirror repos) vs the retained
+      **irreversible carve-out** (merge to a *protected* main / production / security-weakening), so
+      autonomy completes the reversible steps by default and only escalates the true carve-out. Log
+      the autonomy-vs-escalate decision (G8).
+- [ ] AC3 (mirror-ticket Admin semantics): define deterministic Admin-completion for a wiki-mirror
+      ticket with no live GitHub issue (PR body references the mirror path in lieu of `Closes #N`; a
+      mirror-close step flips the ticket file status). Documented + validated.
+- [ ] AC4 (completion gate hardening): the stop/completion gate for `lane:code-change` checks the
+      **branch's committed deliverable is clean + CI-green**, not the unrelated working-tree drift
+      (the 718-untracked false-positive that fires once `collaborator=true`), and emits a clear
+      "reversible-remaining vs carve-out-remaining" message instead of a blanket "Admin incomplete."
+- [ ] AC5 (consensus): the chosen hermetic-path design + the reversible/carve-out taxonomy ratified
+      by a free ≥2-distinct-family cross-model panel (`cross-family-consensus.js`); receipt recorded.
+
+## Non-goals
+
+- Reconciling the entire `#N` mirror universe to real GitHub issues (out of scope; AC3 only defines
+  *completion semantics* for mirror tickets).
+- Weakening the genuine carve-outs (design / UAT / irreversible / security-weakening) or C-G1/C-G4.
+
+## Lane / test_strategy
+
+lane:code-change | test_strategy: research-first Phase-0, then tdd for the classifier + hermetic-path
+change + clean-tree regression.
+
+Related: #2064 (provenance), #3025/#3026 (full-baton-completion + zero-miss precursors),
+#3797 (baseline-restore mirror reality), #3798 (.env/loader hermeticity precedent).


### PR DESCRIPTION
## #3799-AC1 — hermetic baton tooling

Mirror ticket: `wiki/work-log/tickets/3799.md` (no live GitHub issue; issue space caps at #5). This PR
closes **AC1 only**; AC2/AC3/AC4/AC5 remain OPEN and tier-blocked.

### Problem
`scripts/signer-alias.js` `loadRegistry()` read the team-model-signature registry from an **out-of-repo**
path (`<repo>/../inventory/team-model-signatures.json`), absent on a clean `.git`-less archive checkout.
Baton tooling that resolves a signer alias therefore could not run hermetically → normalized
"complete at mirror-level, defer merge" (root causes 1/2 of #3799).

### Change
- `signer-alias.js` — `registryPath()` resolves `BATON_SIGNER_REGISTRY` env → in-repo
  `inventory/team-model-signatures.json` → legacy out-of-repo (back-compat) → clear throw.
- `inventory/team-model-signatures.json` — **NEW, tracked, secret-free** alias subset (no `cryptoKeys`,
  no private-key material). Tracks the baton-tooling dependency closure on `main` (G4 respected).
- `scripts/signer-alias.spec.js` — **NEW** hermetic regression (9 tests incl. secret-free invariant);
  registered in `inventory/harness-self-test-registry.json` (#1893 discipline).
- `scripts/baton-e2e.spec.js` — resolves the signer registry from the in-repo path (no out-of-repo
  fixture write).

### Verification
- **Hermetic**: `git archive feat/3799-ac1-hermetic-signer | tar -x -C /tmp/ci-3799` (clean, no `.git`,
  no `../inventory` sibling), then in `/tmp/ci-3799` with `BATON_SIGNER_REGISTRY` unset:
  `node scripts/signer-alias.spec.js` (9/9), `node scripts/baton-e2e.spec.js` (13/13),
  `node scripts/validator-discipline.spec.js` — all **exit 0**.
- **validator-discipline** over the changeset: `OK — no unguarded validators`.
- **Cross-family consensus**: PASS, receipt `35d7328999ec3357` (groq[meta] + mistral[mistral]).

Behavior preserved for existing dev machines (out-of-repo cryptoKey registry still reachable via
env/legacy path; in-repo alias values mirror the canonical registry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)