### PR TITLE
chore(#3801): capture 39-file live-harness baseline (faithful snapshot)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,28 @@ Thumbs.db
 
 # VS Code workspace-specific
 .vscode/
+
+# Runtime / generated operational artifacts — never committed (regenerated at runtime).
+# Added 2026-07-13 to stop the live operational runtime from polluting the tracked tree.
+# NOTE: authored source (hooks/scripts, instructions, skills, agents) is intentionally
+# NOT ignored — that drift needs human triage + a baton, not a blanket ignore.
+session-state/
+session-store.db
+logs/
+.dashboard/
+hooks/state/
+command-history-state.json
+hamr-config.json
+openclaw-usage.log
+openclaw-model-refresh.json
+vscode.session.metadata.cache.json
+*.session.metadata.cache.json
+# Generated LLM-wiki mirror (Karpathy-pattern, regenerated; never tracked in this checkout)
+wiki/
+
+# Host-local / IDE runtime state — machine-specific or contains live tokens (#3797).
+# /config.json self-describes as "managed automatically"; ide/*.lock holds a live MCP
+# auth nonce + socket + pid; permissions-config.json is keyed to an absolute host path.
+/config.json
+/ide/
+/permissions-config.json

--- a/agents/governance-auditor.agent.md
+++ b/agents/governance-auditor.agent.md
@@ -3,7 +3,7 @@ name: Governance Auditor
 description: Post-merge and post-deploy governance enforcement. Audits CHANGELOG, README sync, community health, docs drift, and learnings.
 tools:
   - '*'
-model: Claude Sonnet 4 (copilot)
+model: Claude Sonnet 4.6 (copilot)
 ---
 
 # Governance Auditor

--- a/agents/planner.agent.md
+++ b/agents/planner.agent.md
@@ -2,11 +2,15 @@
 name: Planner
 description: Research and implementation planning agent. Read-only tools — cannot modify files. Produces structured plans with evidence.
 tools: []
-model: Claude Opus 4 (copilot)
+model: Claude Opus 4.6 (copilot)
 handoffs:
-  - label: Start Implementation
-    agent: agent
+  - label: ⚡ Implement Plan
+    agent: implementer
     prompt: Implement the plan outlined above. Follow the implementation steps in order.
+    send: false
+  - label: 🧠 Architect It
+    agent: architect
+    prompt: Implement the plan outlined above. This requires deep reasoning — use architectural rigor.
     send: false
 ---
 

--- a/agents/release-reviewer.agent.md
+++ b/agents/release-reviewer.agent.md
@@ -3,7 +3,7 @@ name: Release Reviewer
 description: Version integrity, CHANGELOG quality, artifact safety, and documentation synchronization reviewer.
 tools:
   - '*'
-model: Claude Sonnet 4 (copilot)
+model: Claude Sonnet 4.6 (copilot)
 ---
 
 # Release Reviewer

--- a/agents/security-scanner.agent.md
+++ b/agents/security-scanner.agent.md
@@ -3,7 +3,7 @@ name: Security Scanner
 description: Credential and secret exposure scanner. Audits files, git history, package artifacts, and CI workflows for leaked secrets.
 tools:
   - '*'
-model: Claude Sonnet 4 (copilot)
+model: Claude Sonnet 4.6 (copilot)
 ---
 
 # Security Scanner
@@ -14,7 +14,7 @@ You are a security-focused scanner. Your sole purpose is to find and prevent cre
 
 ### 1. Live File Scan
 Search the workspace for files containing potential secrets:
-- API keys: patterns like `sk-`, `ghp_`, `gho_`, `Bearer `, `token`, `secret`, `password`
+- API keys: patterns like `sk-`, `ghp_`, `gho_`, `Bearer`, `token`, `secret`, `password`
 - `.env` files with real values (not placeholders)
 - Private keys: `-----BEGIN`, `.pem`, `.key`, `id_rsa`, `id_ed25519`
 - Hard-coded credentials in source files

--- a/hooks/scripts/posttool_reminders.py
+++ b/hooks/scripts/posttool_reminders.py
@@ -1,33 +1,23 @@
 #!/usr/bin/env python3
-"""PostToolUse hook: detect doc-trigger edits AND git commit/push commands.
-
-Two independent triggers:
-1. File edits to docs/config files -> standards reminder
-2. Terminal commands containing 'git commit' or 'git push' -> governance checklist
-"""
+"""PostToolUse hook: governance reminders for docs/release hygiene + context re-injection."""
 import json
 import re
 import sys
-from typing import Any, Iterable
+from pathlib import Path
 
-DOC_TRIGGER_RE = re.compile(
-    r"(^|/)(README\.md|CHANGELOG\.md|docs/|\.github/workflows/"
-    r"|package\.json|pyproject\.toml|Cargo\.toml|pom\.xml|\.vscodeignore)$"
-)
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
 
-GIT_COMMIT_RE = re.compile(r"\bgit\s+commit\b")
-GIT_PUSH_RE = re.compile(r"\bgit\s+push\b")
+from admin_patterns import RE_GIT_COMMIT, RE_GIT_PUSH, iter_strings
+from governance_state import ensure_state, mark_tool_activity, save_state
+from precompact_anchor import ANCHOR
+from wiki_wisdom import governance_enforcement, post_merge_checklist
 
+GOVERNANCE_ANCHOR_INTERVAL = 15
 
-def iter_strings(value: Any) -> Iterable[str]:
-    if isinstance(value, str):
-        yield value
-    elif isinstance(value, dict):
-        for v in value.values():
-            yield from iter_strings(v)
-    elif isinstance(value, list):
-        for v in value:
-            yield from iter_strings(v)
+DOC_TRIGGER_RE = re.compile(r"(^|/)(README\.md|CHANGELOG\.md|docs/|\.github/workflows/|\.github/CONTRIBUTING\.md|\.github/PULL_REQUEST_TEMPLATE\.md|package\.json|pyproject\.toml|Cargo\.toml|pom\.xml|\.vscodeignore)$")  # noqa: E501
+CODE_TRIGGER_RE = re.compile(r"(^|/)(mem-watchdog\.sh|install\.sh|mem-watchdog\.service|vscode-extension/.*\.(js|ts|json)|scripts/.*\.sh|tests/.*\.sh)$")  # noqa: E501
 
 
 def main() -> int:
@@ -37,49 +27,72 @@ def main() -> int:
         return 0
 
     tool = str(payload.get("tool_name", ""))
-    tool_input = payload.get("tool_input", {})
-    values = list(iter_strings(tool_input))
+    values = list(iter_strings(payload.get("tool_input", {})))
     joined = "\n".join(values)
 
+    cwd = str(payload.get("cwd", "")) or str(Path.cwd())
+    state = ensure_state(cwd)
+    mark_tool_activity(state, payload)
+
+    flags = state.get("flags", {})
+    ops = state.get("admin_ops", {})
+    repo_type = state.get("repo_type", "generic")
     messages = []
 
-    # Trigger 1: doc/config file edits
+    # Periodic governance anchor re-injection every N bash calls
+    if tool in {"run_in_terminal", "terminal", "runTerminalCommand", "Bash"}:
+        ctr = state.get("bash_call_ctr", 0) + 1
+        state["bash_call_ctr"] = 0 if ctr >= GOVERNANCE_ANCHOR_INTERVAL else ctr
+        if ctr >= GOVERNANCE_ANCHOR_INTERVAL:
+            messages.insert(0, f"[GOVERNANCE ANCHOR — periodic reminder] {ANCHOR}")
+
+    save_state(state)
+
     if any(DOC_TRIGGER_RE.search(v) for v in values):
+        messages.append(governance_enforcement())
+    if any(CODE_TRIGGER_RE.search(v) for v in values):
         messages.append(
-            "Standards reminder: validate version integrity, run relevant checks, "
-            "audit distributable artifacts for secret files, and sync docs to "
-            "behavior/config changes."
+            "Doc coverage matrix: root README, extension README, "
+            "CHANGELOG(s), design docs, contribution/governance docs."
         )
 
-    # Trigger 2: git commit or push in terminal
-    if tool in {"run_in_terminal", "terminal", "runTerminalCommand"}:
-        if GIT_PUSH_RE.search(joined):
+    if tool in {"run_in_terminal", "terminal", "runTerminalCommand", "Bash"}:
+        if RE_GIT_PUSH.search(joined):
+            messages.append(post_merge_checklist())
+        elif RE_GIT_COMMIT.search(joined):
             messages.append(
-                "Pre-push governance gate: have you run "
-                "scripts/docs-integrity-check.sh? The pre-push hook will run it "
-                "automatically, but verify: README badge, CHANGELOG version, "
-                "copilot-instructions test count, and ci.yml comment all match "
-                "actual npm test output."
-            )
-        elif GIT_COMMIT_RE.search(joined):
-            messages.append(
-                "Post-commit governance check: if this commit changes code behavior, "
-                "ensure CHANGELOG, README, system-stability.md, and copilot-instructions.md "
-                "are updated in the same commit or a follow-up before pushing."
+                "Post-commit: if behavior/config changed, update docs "
+                "in same commit or immediate follow-up."
             )
 
+    if flags.get("code_touched"):
+        if not state.get("roles", {}).get("manager"):
+            messages.append(
+                "Governance alert: code changes were made before Manager scope was recorded. "
+                "Create or link an issue and perform Manager handoff."
+            )
+        missing = [k for k in ("commit", "push", "pr_create", "ci_green", "merge") if not ops.get(k)]
+        if missing:
+            messages.append(f"Admin baton incomplete — missing: {', '.join(missing)}.")
+        if not ops.get("issue_linked"):
+            messages.append(
+                "Ticket gate: code was touched but no GitHub issue is linked. "
+                "Run `gh issue create` or reference an existing issue."
+            )
+
+    if repo_type == "vscode-extension" and flags.get("extension_touched"):
+        ext_missing = [k for k in ("publish", "release_integrity", "gh_release") if not ops.get(k)]
+        if ext_missing:
+            messages.append(f"Extension baton incomplete — missing: {', '.join(ext_missing)}.")
+
     if messages:
-        out = {
+        print(json.dumps({
             "hookSpecificOutput": {
                 "hookEventName": "PostToolUse",
                 "additionalContext": " | ".join(messages),
             },
-            "systemMessage": "Governance reminder injected after "
-            + ("doc edit" if len(messages) == 1 and "Standards" in messages[0]
-               else "git operation detected") + ".",
-        }
-        print(json.dumps(out))
-
+            "systemMessage": "Governance state updated; baton reminders injected.",
+        }))
     return 0
 
 

--- a/hooks/scripts/pretool_guard.py
+++ b/hooks/scripts/pretool_guard.py
@@ -1,62 +1,757 @@
 #!/usr/bin/env python3
-import json
-import re
-import sys
-from typing import Any, Iterable
+"""PreToolUse hook: pre-tool guards and admin sequencing gates."""
+import json, os, re, subprocess, sys
+from pathlib import Path
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path: sys.path.insert(0, str(SCRIPT_DIR))
+from admin_patterns import (  # noqa: E501
+    DANGEROUS_CMD_RE, RE_GH_ISSUE_CLOSE, RE_GH_RELEASE_CREATE, RE_GIT_COMMIT,
+    RE_GIT_PUSH, RE_GIT_TAG, RE_PR_CHECKS, RE_PR_CREATE, RE_PR_MERGE,
+    RE_RELEASE_INTEGRITY, RE_VSCE_PUBLISH, SECRET_FILE_RE, iter_paths, iter_strings)
+from canonical_main_enforcer import is_main_checkout, evaluate_path, main_checkout_root
+from blast_radius_cap import ENV_BYPASS, check_caps, emit_cap_incident, load_caps
+from session_anomaly import (
+    ENV_ANOMALY_BYPASS, check_anomaly, emit_anomaly_incident,
+)
+from governance_state import ensure_state, save_state
+from baton_handoff_checks import linked_issue_has_authoritative_manager_handoff
+from one_ticket_per_worktree import check_one_ticket_per_worktree
+from live_checks import ci_gate_status, ci_gate_status_stable, linked_issue_has_collab_handoff, linked_issue_has_manager_handoff, linked_issue_has_planning_consensus, check_merged_pr, open_pr_for_ref
+from runtime_paths import runtime_hook_paths
+RE_ISSUE_REF = re.compile(r"#\d+")
+RE_BRANCH_TICKET = re.compile(r"^(feat|fix|hotfix)/(\d+)-")
+RE_BRANCH_CREATE = re.compile(r"git\s+(?:checkout\s+-b|switch\s+-c)\s+(\S+)")
+RE_BRANCH_SWITCH = re.compile(
+    r"(?:(?:^|;|&&|\|\|)\s*)git\s+(?:switch|checkout)\s+(?!-[bcCq])([^\s-]\S*)",
+    re.MULTILINE,
+)
+BRANCH_VALID = re.compile(r"^(feat|fix|hotfix)/\d+-|^(chore|skill)/[a-z0-9]|^main$|^develop$")
+RE_PR_REF = re.compile(r"gh\s+pr\s+merge\s+(\S+)")
+IT_OPS_MARKERS_RE = re.compile(r"\[it-ops\]|chore\(it-ops\)\s*:", re.IGNORECASE)
+NO_CODE_ADMIN_RE = re.compile(
+    r"\bgit\s+add\b|\bgit\s+commit\b|\bgit\s+push\b|"
+    r"\bgh\s+pr\s+(?:create|merge)\b|\bnpm\s+run\s+deploy(?:[:\w-]*)?\b|"
+    r"\bnpx\s+vsce\s+publish\b|\bgh\s+release\s+create\b",
+    re.IGNORECASE,
+)
 
-SECRET_FILE_RE = re.compile(r"(^|/)(\.env(\..*)?|id_rsa|id_ed25519|.*\.pem|.*\.key)$")
-DANGEROUS_CMD_RE = re.compile(r"\brm\s+-rf\s+/(\s|$)|\bmkfs\b|\bdd\s+if=|\bDROP\s+TABLE\b", re.IGNORECASE)
+def detect_it_ops_bypass(joined: str, env: dict | None = None) -> tuple[bool, str | None]:
+    """#2142: IT-ops commit-gate bypass detector.
+
+    Returns (True, marker) if any of the documented markers matches:
+    - env var MEGINGJORD_IT_OPS=1
+    - commit message contains [it-ops] literal
+    - commit message uses chore(it-ops): Conventional-Commits type prefix
+    Returns (False, None) otherwise.
+    """
+    env = env if env is not None else os.environ
+    if env.get("MEGINGJORD_IT_OPS") == "1":
+        return True, "env:MEGINGJORD_IT_OPS=1"
+    if IT_OPS_MARKERS_RE.search(joined):
+        return True, "commit-subject-marker"
+    return False, None
+
+# #2995: shell-level write-target detection — closes the canonical-main blind spot
+# where terminal writes (redirect / sed -i / tee / cp / mv) mutate tracked files,
+# bypassing the structured-edit-tool enforcer. evaluate_path() is the deny/allow
+# authority (only tracked, non-gitignored, in-repo paths are denied), so generous
+# extraction is safe; the extractor only narrows WHICH tokens to evaluate.
+_SHELL_DEV_SINKS = {"/dev/null", "/dev/stdout", "/dev/stderr", "/dev/tty"}
+# `>`/`>>` file redirects, anchored to a word boundary (#3001): the operator must be
+# at start-of-string or after whitespace, optionally with a leading fd digit. This
+# excludes arrow tokens (`->`, `=>`) and inline comparisons (`a>b`) that previously
+# matched and over-blocked. fd-dup forms (`2>&1`, `>&2`) are excluded because the
+# capture class rejects a leading `&`. (Residual: `&>file` all-output redirect is not
+# matched — uncommon; tee/redirect/dd cover the usual writers.)
+_REDIRECT_RE = re.compile(r"(?:^|\s)\d*>>?(?!=)\s*([^\s;&|<>()`]+)")
+_TEE_RE = re.compile(r"\btee\b\s+(?:-{1,2}\S+\s+)*([^\s;&|<>()`]+)")
+# sed in-place: take the last bare token of the sed command segment as the target.
+# (Multi-file `sed -i s f1 f2` checks the last file only — a documented residual.)
+_SED_I_RE = re.compile(r"\bsed\b\s+[^|;&\n]*?-i\S*\s+[^|;&\n]*?\s([^\s;&|<>()`]+)(?=\s|$|;|\||&)")
+# cp/mv/install: destination is the last token of the command segment.
+_CP_MV_RE = re.compile(r"\b(?:cp|mv|install)\b\s+[^|;&\n]*?\s([^\s;&|<>()`]+)(?=\s|$|;|\||&)")
+# dd of=PATH (#2995 cross-family review): a common non-redirect file writer.
+_DD_RE = re.compile(r"\bdd\b[^|;&\n]*?\bof=([^\s;&|<>()`]+)")
+
+# #3471: quote/here-doc-aware sanitization so a `>` / `>=` that is PROSE (inside a quoted
+# string, a here-doc body, or a description field) is not parsed as a shell redirect and
+# false-blocked as a write. Real redirects to UNQUOTED targets survive and are still caught.
+_QUOTE_SENTINEL = "\x00"
+_HEREDOC_RE = re.compile(r"<<-?\s*(['\"]?)(\w+)\1")
 
 
-def iter_strings(value: Any) -> Iterable[str]:
-    if isinstance(value, str):
-        yield value
-    elif isinstance(value, dict):
-        for v in value.values():
-            yield from iter_strings(v)
-    elif isinstance(value, list):
-        for v in value:
-            yield from iter_strings(v)
+def _strip_heredoc_bodies(cmd: str) -> str:
+    """Drop here-doc body lines (data, not shell) so a `>`/`>=` in the body is not a redirect.
+    Keeps the `<<DELIM` opening line (its own redirect, if any, stays detectable). Handles
+    <<EOF, <<'EOF', <<-EOF; the terminator is a line whose stripped text equals the delimiter.
+    """
+    lines = cmd.split("\n")
+    kept: list[str] = []
+    index = 0
+    while index < len(lines):
+        kept.append(lines[index])
+        match = _HEREDOC_RE.search(lines[index])
+        if match:
+            delimiter = match.group(2)
+            index += 1
+            while index < len(lines) and lines[index].strip() != delimiter:
+                index += 1  # skip body line
+            # skip the terminator line too (the trailing increment moves past it)
+        index += 1
+    return "\n".join(kept)
+
+
+def _mask_quoted(cmd: str) -> str:
+    """Replace the CONTENT of single/double/backtick-quoted spans with a NUL sentinel so a
+    `>` inside a quoted string vanishes while quote structure (and a quoted redirect-target
+    POSITION) is preserved. Respects backslash-escapes outside single quotes.
+    """
+    out: list[str] = []
+    index, length = 0, len(cmd)
+    while index < length:
+        char = cmd[index]
+        if char in "'\"`":
+            quote = char
+            index += 1
+            while index < length and cmd[index] != quote:
+                if cmd[index] == "\\" and quote != "'":
+                    index += 1
+                index += 1
+            out.append(_QUOTE_SENTINEL)
+            index += 1  # consume the closing quote (or past end if unterminated)
+        else:
+            out.append(char)
+            index += 1
+    return "".join(out)
+
+
+def _sanitize_for_redirect_scan(cmd: str) -> str:
+    """Here-doc bodies stripped + quoted spans masked before the redirect regex scan (#3471).
+    Fail-open: any error returns the original command (never brick the hook).
+    """
+    try:
+        return _mask_quoted(_strip_heredoc_bodies(cmd))
+    except Exception:
+        return cmd
+
+
+def shell_write_targets(joined: str) -> list[str]:
+    """Best-effort extraction of file-write targets from a shell command.
+
+    Covers the common idioms an agent uses to mutate files via the terminal:
+    `> f`, `>> f`, `tee f`, `sed -i ... f`, `cp/mv/install ... f`, `dd of=f`.
+    fd-redirects (`2>&1`, `>&2`) and `/dev/*` sinks are excluded. Returns raw target
+    tokens; callers MUST pass each through evaluate_path() — that is the deny/allow
+    authority, so over-extraction here is harmless (non-repo / gitignored targets
+    resolve to ALLOW). Fail-open: any parse error yields [] (never brick the hook).
+
+    RESIDUAL (defense-in-depth, not airtight — documented per #2995 cross-family
+    review): arbitrary in-process writers (`python -c "open(...,'w')"`,
+    `node -e fs.writeFileSync`), `patch < diff`, non-interactive editors
+    (`vim -c w`, `emacs --batch`), and multi-file `sed -i` (last file only) are NOT
+    parsed — they cannot be detected by static shell-token analysis. The structured
+    edit-tool enforcer (evaluate_path on Edit/Write/create_file/...) remains the
+    primary guard; this closes the common terminal-write idioms.
+    """
+    targets: list[str] = []
+    try:
+        cleaned = _sanitize_for_redirect_scan(joined)
+        for regex in (_REDIRECT_RE, _TEE_RE, _SED_I_RE, _CP_MV_RE, _DD_RE):
+            for match in regex.finditer(cleaned):
+                token = match.group(1).strip().strip("\"'")
+                if not token or token.startswith("-") or token.startswith("&"):
+                    continue
+                if _QUOTE_SENTINEL in token:
+                    continue  # #3471: quoted redirect target — documented residual (not path-evaluated)
+                if token in _SHELL_DEV_SINKS:
+                    continue
+                targets.append(token)
+    except Exception:
+        return []
+    return targets
+
+# Epic #3392 AC2/AC5 (#3403): adjudicate-first risk classifiers for the 2 security-sensitive
+# surfaces (S6 hook-mutation, S7 sensitive-path). Mirrors the #3401 adjudication-guardrail
+# risk-tiering — a FAST in-process decision (no synchronous network panel; G7), reserving the
+# human carve-out for genuine risk only. Both are FAIL-CLOSED: any error returns "ask" so a
+# classifier bug can never silently weaken G4. ("allow" means "benign — fall through to the other
+# gates", NOT short-circuit-allow.)
+# A GOVERNED deploy is ONLY `npm run deploy|sync[:variant]` or a deploy/sync shell script — NOT a
+# bare `deploy:word` token (a cross-family security review flagged that bare form as too permissive:
+# `echo deploy:malicious` alongside a hook write would have been mis-allowed). Tightened to fail
+# toward the carve-out: an unrecognized hook write reaches the human (ask), not allow.
+_DEPLOY_RE = re.compile(r"\bnpm\s+run\s+(?:deploy|sync)[:\w-]*|\b(?:deploy|sync)\.sh\b")
+
+def classify_hook_mutation(joined: str) -> str:
+    """S6: 'allow' a benign hook READ/inspect or a GOVERNED deploy that writes hooks; 'ask' on a
+    direct ungoverned hook MUTATION (policy-weakening risk). Fail-closed → 'ask'.
+    """
+    try:
+        hook_paths = runtime_hook_paths()
+        targets = shell_write_targets(joined)
+        mutates_hook = any(any(hp in target for hp in hook_paths) for target in targets)
+        if not mutates_hook:
+            return "allow"  # read / inspect only — benign
+        if _DEPLOY_RE.search(joined):
+            return "allow"  # governed deploy/sync writes hooks legitimately
+        return "ask"  # direct ungoverned hook mutation — human carve-out preserved (G4)
+    except Exception:
+        return "ask"  # fail-closed: never silently weaken the guard
+
+def classify_sensitive_path(values: list[str], cwd: str) -> str:
+    """S7: 'allow' read/source of a gitignored-LOCAL secret file (the operator's own .env); 'ask'
+    when a secret-file path is TRACKED/committable (secret-exposure risk). Fail-closed → 'ask'.
+    """
+    try:
+        secret_paths = [p for p in values
+                        if SECRET_FILE_RE.search(p) and not p.endswith(".env.example")]
+        if not secret_paths:
+            return "allow"
+        for path in secret_paths:
+            allowed, _ = evaluate_path(path, cwd)
+            if not allowed:
+                return "ask"  # tracked/committable secret-file path → exposure carve-out (G4)
+        return "allow"  # all are gitignored local config — benign local use
+    except Exception:
+        return "ask"  # fail-closed
+
+def current_branch(cwd: str) -> str | None:
+    try:
+        res = subprocess.run(["git", "branch", "--show-current"], cwd=cwd,
+                             check=False, capture_output=True, text=True)
+        b = (res.stdout or "").strip()
+        return b or None
+    except Exception:
+        return None
+
+def emit(decision: str, reason: str, extra: str | None = None) -> int:
+    hook = {"hookEventName":"PreToolUse","permissionDecision":decision,"permissionDecisionReason":reason}
+    if extra: hook["additionalContext"] = extra
+    print(json.dumps({"hookSpecificOutput": hook}))
+    if decision == "deny":
+        try:
+            from baton_event_emitter import emit_decision as _ed
+            _ed("pretool-guard", "tool-denied", "denied", rationale=reason)
+        except Exception:
+            pass  # G6: telemetry never breaks the gate
+    return 0
+
+def _emit_it_bypass_telemetry(marker: str, cwd: str) -> None:
+    """Refs #2351: best-effort IT-bypass usage telemetry. Never blocks the hook."""
+    try:
+        from it_bypass_emit import emit_bypass
+        emit_bypass(marker, cwd)
+    except Exception:
+        pass  # telemetry failure must not affect hook decision
+
+def _active_ticket_labels(state: dict, cwd: str) -> set[str]:
+    ticket = state.get("active_ticket")
+    if not ticket:
+        return set()
+    try:
+        res = subprocess.run(
+            ["gh", "issue", "view", str(ticket), "--json", "labels", "-q", ".labels[].name"],
+            cwd=cwd, check=False, capture_output=True, text=True, timeout=20,
+        )
+        return {line.strip() for line in (res.stdout or "").splitlines() if line.strip()}
+    except Exception:
+        return set()
+
+def active_ticket_is_no_code_lane(state: dict, cwd: str) -> bool:
+    return "lane:no-code-remediation" in _active_ticket_labels(state, cwd)
+
+def active_ticket_is_research_lane(state: dict, cwd: str) -> bool:
+    """#3266: True when the active ticket is lane:research (report-only, PR-less and
+    merge-less by design). Mirrors active_ticket_is_no_code_lane; consumed by the
+    issue-close carve-out here and by the Stop-hook Admin-op gate (stop_reminder ->
+    stop_checks.check_admin_ops -> admin_patterns.required_admin_ops).
+    """
+    return "lane:research" in _active_ticket_labels(state, cwd)
+
+DOCS_LANE_LABELS = ("lane:docs-research", "lane:docs-only")
+
+def active_ticket_is_docs_lane(state: dict, cwd: str) -> bool:
+    """#3569: True when the active ticket is lane:docs-research or lane:docs-only — report-only
+    "Manager+Consultant" reduced batons that are PR-less/merge-less by design. Sibling to
+    active_ticket_is_research_lane (left unchanged per #3569 D1); consumed by the same issue-close
+    carve-out here and the Stop-hook Admin-op gate. NOTE: the caller's clean-tree condition is
+    load-bearing for docs lanes — docs work often DOES produce a tracked docs diff, and such a
+    real diff must still deny + re-route to lane:code-change; only a genuinely-empty tree is exempt.
+    """
+    labels = _active_ticket_labels(state, cwd)
+    return any(label in labels for label in DOCS_LANE_LABELS)
+
+CONSENSUS_OVERRIDE_ENV = "MEGINGJORD_PLANNING_CONSENSUS_OVERRIDE"
+
+def _emit_planning_consensus_override_incident(cwd: str, ticket: int | None) -> None:
+    """Best-effort incident for audited planning-consensus override usage (#2971)."""
+    try:
+        path = os.path.join(os.path.expanduser("~"), ".megingjord", "incidents.jsonl")
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        event = {"version": 3, "service": "pretool-guard-consensus", "env": "local",
+                 "event": "governance.planning-consensus-override",
+                 "pattern_id": "planning-consensus-override", "severity": "medium",
+                 "cwd": cwd, "ticket": ticket}
+        with open(path, "a", encoding="utf-8") as handle:
+            handle.write(json.dumps(event) + "\n")
+    except Exception:
+        pass
+
+RE_ADMIN_OVERRIDE = re.compile(r"(?:^|\s)--admin(?:[=\s]|$)")
+MUTATING_TOOLS = {
+    "create_file", "apply_patch", "edit_notebook_file", "create_new_jupyter_notebook",
+    "replace_string_in_file", "multi_replace_string_in_file", "Write", "Edit", "MultiEdit",
+    "write_to_file", "replace_file_content", "multi_replace_file_content",
+    "run_in_terminal", "terminal", "runTerminalCommand", "Bash", "run_command", "send_command_input",
+}
+
+
+def enforce_blast_radius(tool: str, state: dict, cwd: str) -> int | None:
+    if tool not in MUTATING_TOOLS:
+        return None
+    reason = check_caps(state.get("blast_radius", {}), load_caps(cwd))
+    if not reason:
+        return None
+    override = os.environ.get(ENV_BYPASS, "0") == "1"
+    emit_cap_incident(reason, cwd, override=override)
+    if override:
+        return None
+    return emit("deny", f"Session blast-radius cap exceeded: {reason}")
+
+def enforce_session_anomaly(state: dict, cwd: str) -> int | None:
+    """#2913: deny when session aggregate counters exceed anomaly thresholds (G-15).
+    #3316: MEGINGJORD_SESSION_ANOMALY_DISABLED=1 bypasses (audited incident still
+    emitted) for parity with the blast-radius cap override.
+    """
+    reason = check_anomaly(state, cwd)
+    if not reason:
+        return None
+    override = os.environ.get(ENV_ANOMALY_BYPASS, "0") == "1"
+    emit_anomaly_incident(reason, cwd, override=override)
+    if override:
+        return None
+    return emit("deny",
+        f"Session anomaly detected — human review required: {reason}. "
+        "Refs #2913 (G-15 / ASI05 / EU-AI-Act-Art14).")
+
+def require_bypass_exception(joined: str, state: dict, cwd: str) -> bool:
+    """True when this is an admin-OVERRIDE merge lacking the Epic #2517 exception (#2706).
+    Fail-CLOSED: once the command is a confirmed override, if the exception cannot be
+    verified (label backend error) require it (return True) rather than silently bypass -
+    consistent with the unbreakable-chain invariant. The except never re-raises, so a guard
+    bug yields a recoverable deny, not a crash/brick. Non-override commands short-circuit
+    to False before any throwable call.
+    """
+    if not RE_ADMIN_OVERRIDE.search(joined):
+        return False
+    try:
+        return "merge-bypass:admin-exception" not in _active_ticket_labels(state, cwd)
+    except Exception:
+        return True
+
+# Bounded {0,512} quantifier caps the backtracking window (#2739 cross-family review
+# hardening): a curl command line longer than this never legitimately targets a fleet host.
+RE_FLEET_CURL = re.compile(r"curl\b[^\n|]{0,512}(?::11434\b|/api/(?:generate|tags|chat)\b)")
+
+def is_raw_fleet_curl(joined: str) -> bool:
+    """True when a raw curl targets a fleet/ollama endpoint outside the dispatch
+    wrappers without the documented carve-out (#2192 vector #2 - raw curl bypasses
+    HAMR cost+observability). Fail-open: any error returns False (never brick).
+    """
+    try:
+        if "hamr-bypass-ok" in joined:
+            return False
+        return bool(RE_FLEET_CURL.search(joined))
+    except Exception:
+        return False
+
+def _emit_fleet_bypass_incident(cwd: str) -> None:
+    """Append a Tier-1 incident for a raw-fleet-curl bypass (#2192 AC1). Never raises."""
+    try:
+        path = os.path.join(os.path.expanduser("~"), ".megingjord", "incidents.jsonl")
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        event = {"version": 3, "service": "pretool-guard-fleet-bypass",
+                 "env": "local", "event": "governance.raw-fleet-curl-bypass",
+                 "pattern_id": "raw-fleet-curl-bypasses-hamr", "severity": "low", "cwd": cwd}
+        with open(path, "a", encoding="utf-8") as handle:
+            handle.write(json.dumps(event) + "\n")
+    except Exception:
+        pass  # telemetry failure must not affect the hook decision
+
+def _emit_worktree_push_desync(cwd: str) -> None:
+    """Append a Tier-1 incident when a push is allowed via the worktree fallback
+    rather than the session commit flag (#3168 AC3). Never raises.
+    """
+    try:
+        path = os.path.join(os.path.expanduser("~"), ".megingjord", "incidents.jsonl")
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        event = {"version": 3, "service": "pretool-guard-worktree-push",
+                 "env": "local", "event": "governance.worktree-push-commit-desync",
+                 "pattern_id": "worktree-push-gate-commit-desync", "severity": "low", "cwd": cwd}
+        with open(path, "a", encoding="utf-8") as handle:
+            handle.write(json.dumps(event) + "\n")
+    except Exception:
+        pass  # telemetry failure must not affect the hook decision
+
+def _read_body_file(path: str, cwd: str) -> str:
+    """#2967: read a `--body-file` target (cwd-relative or absolute) for baton-artifact
+    detection. Returns '' on any error so the guard never breaks on a missing file.
+    """
+    try:
+        full = path if os.path.isabs(path) else os.path.join(cwd, path)
+        with open(full, "r", encoding="utf-8") as handle:
+            return handle.read()
+    except Exception:
+        return ""
+
+def _check_auth_profile(joined: str) -> int | None:
+    """#2910: enforce active authorization profile before privileged operations."""
+    try:
+        from auth_profile_enforcer import check_command
+        result = check_command(joined)
+        if result is not None:
+            allowed, reason = result
+            if not allowed:
+                return emit("deny", reason)
+    except Exception:
+        pass
+    return None
+
+
+def _check_role_tool_allowlist(joined: str, state: dict) -> int | None:
+    """#2919: enforce role-scoped tool allowlist based on active baton phase (G-16)."""
+    try:
+        from role_tool_allowlist_enforcer import check_command as _rtl_check
+        result = _rtl_check(joined, state.get("current_phase"))
+        if result is not None:
+            allowed, reason = result
+            if not allowed:
+                return emit("deny", reason)
+    except Exception:
+        pass
+    return None
+
+
+def _check_epic_close_guard(joined: str, cwd: str) -> int | None:
+    """#3350 AC3: block closing a type:epic issue that still has open children."""
+    try:
+        from epic_close_guard import check_command as _epic_close_check
+        result = _epic_close_check(joined, cwd)
+        if result is not None:
+            allowed, reason = result
+            return emit("allow", reason) if allowed else emit("deny", reason)
+    except Exception:
+        pass
+    return None
+
+
+def check_terminal(joined: str, state: dict, cwd: str) -> int | None:
+    auth_result = _check_auth_profile(joined)
+    if auth_result is not None:
+        return auth_result
+    role_result = _check_role_tool_allowlist(joined, state)
+    if role_result is not None:
+        return role_result
+    epic_close_result = _check_epic_close_guard(joined, cwd)
+    if epic_close_result is not None:
+        return epic_close_result
+    flags, ops = state.get("flags", {}), state.get("admin_ops", {})
+    repo_type = state.get("repo_type", "generic")
+    # #2967: one-ticket-per-worktree — refuse a baton artifact for a second,
+    # still-unresolved ticket from this worktree (provider-neutral, fail-open).
+    one_ticket_deny = check_one_ticket_per_worktree(
+        joined, state, body_file_reader=lambda path: _read_body_file(path, cwd))
+    if one_ticket_deny:
+        return emit("deny", one_ticket_deny)
+    no_code_lane = active_ticket_is_no_code_lane(state, cwd)
+    research_lane = active_ticket_is_research_lane(state, cwd)  # #3266
+    docs_lane = active_ticket_is_docs_lane(state, cwd)  # #3569
+    if no_code_lane and NO_CODE_ADMIN_RE.search(joined):
+        return emit("deny", "No-code remediation lane is issue-only. Admin/implementation commands are blocked; re-route to lane:code-change.")
+    if is_raw_fleet_curl(joined):
+        _emit_fleet_bypass_incident(cwd)
+        # Epic #3392 AC2 (S1): self-resolvable REDIRECT, not a client prompt. The operator
+        # uses the dispatch wrappers (cascade-dispatch / free-cloud-dispatch) so HAMR records
+        # cost+observability, or adds the documented '# hamr-bypass-ok: <reason>' carve-out for an
+        # audited diagnostic. The deny + bypass-incident are PRESERVED (anti-goal §6) — only ask->deny.
+        return emit("deny", "Raw fleet/ollama curl (#2192 vector 2): use cascade-dispatch or "
+                    "free-cloud-dispatch (HAMR cost+observability), or add '# hamr-bypass-ok: <reason>' "
+                    "for an audited diagnostic bypass. Operator-resolvable — no client prompt.")
+    if DANGEROUS_CMD_RE.search(joined): return emit("deny","Blocked dangerous terminal command.")
+    if is_main_checkout(cwd):
+        sw = RE_BRANCH_SWITCH.search(joined)
+        if sw and sw.group(1) not in ("main", "master"):
+            return emit("deny", f"Canonical-main read-only: branch switch to '{sw.group(1)}' from main checkout rejected (#2107). Use a worktree (devenv-ops-<team-or-ticket>/) instead.")
+        # #2995: close the shell-level-write blind spot. Terminal writes (redirect,
+        # sed -i, tee, cp, mv) to a tracked main file bypass the structured-edit-tool
+        # enforcer; evaluate_path() denies tracked/non-gitignored in-repo targets.
+        # IT-ops markers are intentionally NOT consulted here — they waive ticket/baton
+        # ceremony only, never the canonical-main read-only policy.
+        for target in shell_write_targets(joined):
+            allowed, reason = evaluate_path(target, cwd)
+            if not allowed:
+                return emit("deny",
+                    f"Canonical-main read-only (#2995): shell write to '{target}' rejected. {reason} "
+                    "IT-ops markers do NOT authorize tracked-file edits in main — use a dedicated "
+                    "worktree (devenv-ops-<team-or-ticket>/) + ticket branch.")
+    m = RE_BRANCH_CREATE.search(joined)
+    if m and not BRANCH_VALID.match(m.group(1)):
+        return emit("deny",f"Branch '{m.group(1)}' violates naming. Use feat/<ticket#>-desc.")
+    if any(marker in joined for marker in runtime_hook_paths()):
+        # Epic #3392 #3403 (S6): adjudicate-first. Benign hook read / governed deploy → fall
+        # through (proceed); only a direct ungoverned hook MUTATION reaches the human carve-out.
+        if classify_hook_mutation(joined) == "ask":
+            return emit("ask", "Direct ungoverned hook-script mutation detected. Manual approval "
+                        "required — review for policy weakening (Epic #3392 security carve-out).",
+                        "Review for policy weakening.")
+    if RE_GIT_COMMIT.search(joined):
+        bypass, marker = detect_it_ops_bypass(joined)
+        if bypass:
+            _emit_it_bypass_telemetry(marker, cwd)
+            return emit("allow", f"IT-ops commit bypass (#2142): {marker}")
+        if not RE_ISSUE_REF.search(joined):
+            return emit("deny","Commit blocked: no issue ref (#N). Link a ticket first.")
+        branch = current_branch(cwd)
+        match = RE_BRANCH_TICKET.match(branch or "")
+        if match:
+            expected = f"#{match.group(2)}"
+            refs = RE_ISSUE_REF.findall(joined)
+            if expected not in refs:
+                return emit("deny", f"Commit blocked: branch ticket {expected} must be referenced in commit message.")
+            mismatched = sorted({ref for ref in refs if ref != expected})
+            if mismatched:
+                return emit("deny", f"Commit blocked: one branch = one ticket. Remove mismatched refs: {', '.join(mismatched)}")
+    if RE_GIT_PUSH.search(joined):
+        # #2878: merged-branch-guard — block pushes to already-merged branches.
+        branch = current_branch(cwd)
+        if branch:
+            merged_pr = check_merged_pr(branch, cwd)
+            if merged_pr:
+                return emit("deny", f"Push blocked: branch '{branch}' was already merged via PR #{merged_pr}. Check out a new branch from main.")
+        if not ops.get("commit"):
+            # #3168: the session cwd is often the main checkout (on `main`, no ticket
+            # commits) while the work lives in a linked worktree. Resolve the pushed
+            # branch's worktree and accept the commit step there (worktree state OR a
+            # real commit ahead of base) rather than falsely blocking the push.
+            from worktree_push_gate import commit_step_satisfied
+            from state_store import load_state
+            satisfied, used_worktree = commit_step_satisfied(
+                joined, cwd, ops.get("commit"), load_state)
+            if not satisfied:
+                return emit("deny", "Push blocked: commit step first (Admin sequencing).")
+            if used_worktree:
+                _emit_worktree_push_desync(cwd)
+    if RE_PR_MERGE.search(joined):
+        override = require_bypass_exception(joined, state, cwd)
+        if override:
+            return emit("deny", "Admin-override merge blocked (#2706): record the Epic #2517 exception "
+                        "FIRST - add the 'merge-bypass:admin-exception' label (or a BLOCKER_NOTE with "
+                        "bypass_reason: + approver:), THEN re-run the override merge.")
+        if not ops.get("pr_create"):
+            # #3344: the cwd-keyed admin_ops.pr_create flag is lost to cwd-churn,
+            # producing a false "PR creation not recorded" block on a genuine,
+            # CI-green PR. Before blocking, verify a real OPEN PR exists for the
+            # merge ref (read-only). Allow ONLY on a confirmed-OPEN PR; fail-CLOSED
+            # (retain the block) when there is no PR or gh is indeterminate.
+            pr_ref_for_verify = RE_PR_REF.search(joined)
+            pr_ref_value = pr_ref_for_verify.group(1) if pr_ref_for_verify else None
+            if open_pr_for_ref(pr_ref_value, cwd) is not True:
+                return emit("deny", "Merge blocked: PR creation not recorded and no open PR confirmed for the merge ref (read-only verify; fail-closed).")
+        pr_m = RE_PR_REF.search(joined)
+        if pr_m:
+            ci_state = ci_gate_status_stable(pr_m.group(1), cwd)
+            if ci_state == "pending-only":
+                return emit("deny", "Merge blocked: required CI checks are still pending. Wait and re-check status only.")
+            if ci_state in {"failing", "unknown"}:
+                return emit("deny", "Merge blocked: required CI checks are not fully green (live API check).")
+        elif not pr_m and not ops.get("ci_green"):
+            return emit("deny","Merge blocked: CI-green not recorded.")
+    if RE_VSCE_PUBLISH.search(joined) and repo_type == "vscode-extension" and flags.get("extension_touched"):
+        if not ops.get("merge"): return emit("deny","Publish blocked: merge not recorded.")
+    if RE_GH_RELEASE_CREATE.search(joined) and repo_type == "vscode-extension" and flags.get("extension_touched"):
+        if not ops.get("publish"): return emit("deny","Release blocked: publish not recorded.")
+    if RE_GH_ISSUE_CLOSE.search(joined):
+        # #3266/#3569: report-only lanes (research, docs-research, docs-only, no-code-remediation)
+        # are PR-less and merge-less BY DESIGN. When the tree is clean there is genuinely nothing
+        # to merge, so the merge-precondition is skipped. But a REAL repo diff means there IS
+        # something to merge — do NOT exempt; re-route to the full code-change baton (anti-abuse
+        # guardrail C, mirrors the no-code-remediation diff-guard). The clean-tree condition is
+        # load-bearing for docs lanes, which often DO produce a legitimate tracked docs diff.
+        report_only_clean_exempt = False
+        if no_code_lane or research_lane or docs_lane:
+            dirty = subprocess.run(
+                ["git", "status", "--porcelain"],
+                cwd=cwd, check=False, capture_output=True, text=True,
+            ).stdout.strip()
+            if dirty:
+                if no_code_lane:
+                    return emit("deny", "No-code remediation lane invalid: repository diff detected. Move ticket to lane:code-change before closeout.")
+                if research_lane:
+                    return emit("deny", "lane:research invalid: repository diff detected. "
+                                "Re-route ticket to lane:code-change before closeout.")
+                return emit("deny", "lane:docs-research/lane:docs-only invalid: repository diff "
+                            "detected. Re-route ticket to lane:code-change before closeout.")
+            if research_lane or docs_lane:
+                report_only_clean_exempt = True  # #3266/#3569: clean report-only lane — nothing to merge
+        if not report_only_clean_exempt and flags.get("code_touched") and not ops.get("merge"): return emit("deny","Issue close blocked: merge not recorded.")
+        if repo_type == "vscode-extension" and flags.get("extension_touched") and not ops.get("release_integrity"):
+            return emit("deny","Issue close blocked: integrity check not recorded.")
+        if "gh issue edit" not in joined and "--remove-label" not in joined:
+            # Epic #3392 AC2 (S2): self-resolvable REDIRECT, not a client prompt. Normalize the
+            # execution-role labels first, then close — fully operator-automatable. The
+            # label-normalization governance intent is PRESERVED (anti-goal §6); only ask->deny.
+            return emit("deny", "Issue close: remove execution role labels first "
+                        "(gh issue edit #N --remove-label role:<X>), then close. "
+                        "Operator-resolvable — no client prompt.")
+    if RE_PR_CREATE.search(joined) and not RE_GIT_COMMIT.search(joined) and not ops.get("commit"):
+        if not linked_issue_has_collab_handoff(cwd):
+            return emit("deny","PR creation blocked: COLLABORATOR_HANDOFF not found on linked issue.")
+        # Epic #3392 AC2 (S3): state-derive instead of prompting. The session admin_ops.commit flag
+        # is often lost to cwd-churn / worktrees (#3344), so confirm a REAL commit ahead of base in
+        # the pushed branch's worktree. Allow on a confirmed commit-ahead; else redirect to commit.
+        from worktree_push_gate import branch_has_commit_ahead, resolve_push_cwd
+        if branch_has_commit_ahead(resolve_push_cwd(joined, cwd)):
+            return emit("allow", "PR creation: a real commit exists ahead of base (state-derived; no client prompt).")
+        return emit("deny", "PR creation: commit step first (Admin sequencing). Operator-resolvable — no client prompt.")
+    if RE_PR_CHECKS.search(joined) and not ops.get("pr_create"):
+        # Epic #3392 AC2 (S4): checking CI status is READ-ONLY and harmless before PR creation (the
+        # operator routinely polls checks on an existing PR). Allow with an advisory; no client prompt.
+        return emit("allow", "CI checks before PR creation: read-only status poll — proceeding (no client prompt).")
+    if RE_RELEASE_INTEGRITY.search(joined) and repo_type == "vscode-extension" and not ops.get("publish"):
+        # Epic #3392 AC2 (S5): a release-integrity check is READ-ONLY verification; running it before
+        # publish is a harmless precondition check. Allow with an advisory; no client prompt.
+        return emit("allow", "Integrity check before publish: read-only verification — proceeding (no client prompt).")
+    if RE_GIT_TAG.search(joined) and flags.get("ui_touched") and not ops.get("visual_qa"):
+        return emit("deny","Tag blocked: visual QA not recorded for UI change.")
+    return None
+
+def _command_string(tool_input) -> str:
+    """The executable command text only — never the tool `description`/metadata (#3471 AC3).
+    Falls back to all string values when no explicit command field is present (fail-open).
+    """
+    if isinstance(tool_input, dict):
+        for key in ("command", "cmd", "script", "commandLine", "shellCommand", "input"):
+            value = tool_input.get(key)
+            if isinstance(value, str) and value.strip():
+                return value
+    return "\n".join(iter_strings(tool_input))
 
 
 def main() -> int:
-    try:
-        payload = json.load(sys.stdin)
-    except Exception:
-        return 0
-
-    tool = str(payload.get("tool_name", ""))
-    tool_input = payload.get("tool_input", {})
-    values = list(iter_strings(tool_input))
-
-    if tool in {"run_in_terminal", "terminal", "runTerminalCommand"}:
-        joined = "\n".join(values)
-        if DANGEROUS_CMD_RE.search(joined):
-            out = {
-                "hookSpecificOutput": {
-                    "hookEventName": "PreToolUse",
-                    "permissionDecision": "deny",
-                    "permissionDecisionReason": "Blocked dangerous terminal command by global policy.",
-                }
-            }
-            print(json.dumps(out))
-            return 0
-
-    suspicious_paths = [v for v in values if "/" in v or "." in v]
-    if any(SECRET_FILE_RE.search(p) and not p.endswith(".env.example") for p in suspicious_paths):
-        out = {
-            "hookSpecificOutput": {
-                "hookEventName": "PreToolUse",
-                "permissionDecision": "ask",
-                "permissionDecisionReason": "Sensitive file path detected (.env/key material). Manual approval required.",
-                "additionalContext": "Use secret-safe patterns and avoid committing or packaging sensitive files.",
-            }
-        }
-        print(json.dumps(out))
-        return 0
-
+    try: payload = json.load(sys.stdin)
+    except Exception: return 0
+    tool = str(payload.get("tool_name",""))
+    values = list(iter_strings(payload.get("tool_input",{})))
+    cwd = str(payload.get("cwd","")) or str(Path.cwd())
+    state = ensure_state(cwd)
+    from state_store import reset_on_branch_change
+    state = reset_on_branch_change(cwd, current_branch(cwd))
+    blast_result = enforce_blast_radius(tool, state, cwd)
+    if blast_result is not None:
+        return blast_result
+    anomaly_result = enforce_session_anomaly(state, cwd)
+    if anomaly_result is not None:
+        return anomaly_result
+    flags = state.get("flags", {})
+    if tool in {"create_file","apply_patch","edit_notebook_file","create_new_jupyter_notebook","replace_string_in_file","multi_replace_string_in_file","Write","Edit","MultiEdit","write_to_file","replace_file_content","multi_replace_file_content"}:
+        # G-07 #2903: /memories/ write guard — block raw file-write tools from targeting
+        # /memories/ paths. Legitimate memory operations MUST use the managed `memory` tool.
+        # Raw writes here are an injection vector: retrieved content can trigger overwriting
+        # session governance rules (ASI04 Memory Poisoning, EU Art.12).
+        for path_val in iter_paths(payload.get("tool_input", {})):
+            if str(path_val).startswith("/memories/") or str(path_val) == "/memories":
+                return emit("deny",
+                    "Write to /memories/ blocked: use the memory tool for memory operations. "
+                    "Raw file writes to /memories/ are a governance injection vector (G-07, #2903).")
+        # #3383 Epic #3380: guardrail-first memory-write poka-yoke (ADVISORY; never denies).
+        # A deterministic-friction note SHOULD become a guardrail, not a context-growing memory
+        # note. Warns (does not block); promotion to blocking is replay-eval-gated. Fail-open.
+        try:
+            from memory_write_guard import check_memory_write
+            _note_body = "\n".join(values)
+            for _mpath in iter_paths(payload.get("tool_input", {})):
+                _decision, _why = check_memory_write(str(_mpath), _note_body)
+                if _decision == "advise":
+                    sys.stderr.write("[memory-guard advisory #3383] " + _why + "\n")
+                    break
+        except Exception:
+            pass
+        if active_ticket_is_no_code_lane(state, cwd):
+            return emit("deny", "File edit blocked: lane:no-code-remediation is issue-only. Re-route ticket to lane:code-change.")
+        # Canonical-main write guard: block writes whether cwd is main checkout
+        # OR target path is an absolute path inside canonical-main (Refs #2945).
+        _main_rt = main_checkout_root()
+        for path_val in iter_paths(payload.get("tool_input", {})):
+            if is_main_checkout(cwd):
+                check_root = cwd
+            elif path_val.startswith("/"):
+                try:
+                    Path(os.path.normpath(path_val)).relative_to(
+                        os.path.normpath(_main_rt))
+                except ValueError:
+                    continue
+                check_root = _main_rt  # absolute path targets canonical-main
+            else:
+                continue
+            allowed, reason = evaluate_path(path_val, check_root)
+            if not allowed:
+                return emit("deny", f"Canonical-main read-only (#2107): {reason}")
+        if not state.get("active_ticket"):
+            from worktree_ticket import resolve_ticket_from_paths, any_path_in_governed_repo
+            edit_paths = list(iter_paths(payload.get("tool_input", {})))
+            # #2586: the gate keys on session cwd (main checkout); derive the real
+            # active ticket from the edited file's worktree branch instead.
+            # #2587: only gate paths that live inside a governed repo.
+            derived = resolve_ticket_from_paths(edit_paths)
+            gated = (not edit_paths) or any_path_in_governed_repo(edit_paths)
+            if not derived and gated:
+                return emit("deny","File edit blocked: no active ticket. Manager must reference a ticket (#N) before edits.")
+        elif not flags.get("code_touched"):
+            # #2876 + #3204: authoritative MANAGER_HANDOFF + collaborator phase
+            if not linked_issue_has_authoritative_manager_handoff(cwd):
+                return emit("deny", "File edit blocked: authoritative MANAGER_HANDOFF with matching worktree_branch required (#3204). Post Manager scope before first code edit.")
+            # #3206: authoritative MH ⇒ collaborator (mirrors userprompt_gate; no "next prompt")
+            if state.get("current_phase") != "collaborator":
+                state["current_phase"] = "collaborator"
+                save_state(state)
+            if not linked_issue_has_planning_consensus(cwd):
+                if os.environ.get(CONSENSUS_OVERRIDE_ENV) == "1":
+                    _emit_planning_consensus_override_incident(cwd, state.get("active_ticket"))
+                    return emit("allow", "Planning-consensus override accepted. Incident recorded for audit.")
+                return emit("deny", "File edit blocked: planning consensus >=93 is not verified on the linked issue. Post a PLANNING_CONSENSUS PASS artifact or use audited override via MEGINGJORD_PLANNING_CONSENSUS_OVERRIDE=1.")
+    if tool in {"run_in_terminal","terminal","runTerminalCommand","Bash","run_command","send_command_input"}:
+        # Refs #2235 — wire #2220 detector as ADVISORY (no deny; emit incident only).
+        # Refs #2236 — when MEGINGJORD_FLEET_DIRECT_BLOCK=1, enforce DENY on fleet-bypass.
+        try:
+            from hamr_bypass_detector import detect_bypass, emit_incident
+            from hamr_fleet_direct_block import should_block, block_message, review_bypass_decision
+            _joined = "\n".join(values)
+            _det = detect_bypass(_joined)
+            emit_incident(_det)
+            _blk = should_block(_det)
+            if _blk.get("block"):
+                return emit("deny", block_message(_det))
+            # #2933 C7: raw cross-family-provider (paid) call in a review context — keep the $0
+            # cascade the default review path. DENY under the block flag; otherwise surface an
+            # advisory on stderr during soak (the incident is already recorded by emit_incident
+            # above, so the raw-bypass metric is captured without a second hook-JSON line).
+            _rev = review_bypass_decision(_det, _joined)
+            if _rev.get("flag"):
+                if _rev.get("block"):
+                    return emit("deny", _rev["message"])
+                print(f"[review-bypass-advisory] {_rev['message']}", file=sys.stderr)
+        except Exception:
+            pass  # detector failure must not break pre-tool flow
+        result = check_terminal(_command_string(payload.get("tool_input", {})), state, cwd)
+        if result is not None: return result
+    suspicious = [v for v in values if "/" in v or "." in v]
+    if any(SECRET_FILE_RE.search(p) and not p.endswith(".env.example") for p in suspicious):
+        # Epic #3392 #3403 (S7): adjudicate-first. Reading/sourcing a gitignored-local secret file
+        # (own .env) → proceed; a tracked/committable secret-file path → ask (exposure carve-out).
+        if classify_sensitive_path(suspicious, cwd) == "ask":
+            return emit("ask", "Sensitive (tracked/committable) secret-file path detected. Manual "
+                        "approval required — possible secret exposure (Epic #3392 carve-out).")
     return 0
-
 
 if __name__ == "__main__":
     raise SystemExit(main())

--- a/hooks/scripts/session_context.py
+++ b/hooks/scripts/session_context.py
@@ -1,13 +1,17 @@
 #!/usr/bin/env python3
-"""SessionStart hook: inject repo-aware governance context.
-
-Detects repo type, signals, and pending governance gaps to front-load
-awareness of which skills and protocols apply.
-"""
+"""SessionStart hook: inject project-type adaptive governance context."""
 import json
 import os
 import sys
 from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from governance_state import ensure_state, reset_state
+from wiki_router import route_wiki_context
+from wiki_wisdom import baton_protocol, governance_enforcement, post_merge_checklist
 
 
 def main() -> int:
@@ -17,10 +21,16 @@ def main() -> int:
         payload = {}
 
     cwd = Path(payload.get("cwd") or os.getcwd())
+    source = str(payload.get("source") or "")
+    if source in {"new", "startup", "clear"}:
+        state = reset_state(str(cwd))
+    else:
+        state = ensure_state(str(cwd))
+    repo_type = state.get("repo_type", "generic")
+
     signals = []
     gaps = []
 
-    # Detect repo features
     if (cwd / ".github" / "workflows").exists():
         signals.append("CI-workflow-repo")
     if (cwd / "vscode-extension").exists() or (cwd / "package.json").exists():
@@ -29,31 +39,47 @@ def main() -> int:
         signals.append("readme-present")
     if (cwd / "CHANGELOG.md").exists() or (cwd / "vscode-extension" / "CHANGELOG.md").exists():
         signals.append("changelog-present")
+    if (cwd / "wiki").exists():
+        signals.append("wiki-present")
 
-    # Check community health gaps
     for fname in ["CONTRIBUTING.md", "CODE_OF_CONDUCT.md", "SECURITY.md", "SUPPORT.md"]:
         found = (cwd / fname).exists() or (cwd / ".github" / fname).exists()
         if not found:
             gaps.append(f"missing:{fname}")
 
-    # Check for CODEOWNERS
     if not (cwd / ".github" / "CODEOWNERS").exists() and not (cwd / "CODEOWNERS").exists():
         gaps.append("missing:CODEOWNERS")
 
-    context_parts = [
-        "Global standards active: root-cause first, evidence before claims, "
-        "secret-safe packaging, version integrity, docs-sync on behavior/config changes.",
-        f"Repo signals: {', '.join(signals) if signals else 'none-detected'}.",
-    ]
+    if repo_type == "vscode-extension":
+        profile = "Profile=vscode-extension: hard admin+release gates."
+    elif repo_type in {"web-app", "website-static"}:
+        profile = "Profile=web: hard admin gates+docs-drift checks."
+    elif repo_type == "infra-automation":
+        profile = "Profile=infra: hard admin gates+governance checks."
+    else:
+        profile = "Profile=generic: hard admin gates for code sessions."
 
-    if gaps:
-        context_parts.append(f"Community health gaps: {', '.join(gaps)}.")
-
-    context_parts.append(
-        "Post-merge governance: after any PR merge or deploy that changes behavior, "
-        "run the post-merge checklist (CHANGELOG, README sync, repo-profile-governance, "
-        "docs-drift-maintenance, learnings). Do not end the task until these are addressed."
+    baton_msg = baton_protocol()
+    standards_msg = governance_enforcement()
+    postmerge_msg = post_merge_checklist()
+    ANCHOR = (
+        "GOVERNANCE ANCHOR (non-negotiable): "
+        "1) One ticket per branch — feat/<N>-desc or fix/<N>-desc. "
+        "2) Manager scope comment BEFORE any file edits. "
+        "3) Commits MUST reference ticket (#N) — deny on missing. "
+        "4) One branch = one ticket = one PR. No bundling. "
+        "5) Baton sequence: Manager→Collaborator→Admin→Consultant. "
+        "6) Goal order: Governance > Quality > Zero Cost > Privacy > Portability > Resilience > Throughput > Observability > Interoperability."
     )
+    context_parts = [
+        ANCHOR, baton_msg, standards_msg,
+        f"Project type: {repo_type}.", profile,
+        f"Signals: {', '.join(signals) if signals else 'none'}.",
+    ]
+    if gaps:
+        context_parts.append(f"Health gaps: {', '.join(gaps)}.")
+    context_parts.extend(route_wiki_context(cwd, repo_type, signals))
+    context_parts.append(postmerge_msg)
 
     out = {
         "hookSpecificOutput": {

--- a/hooks/scripts/stop_reminder.py
+++ b/hooks/scripts/stop_reminder.py
@@ -1,45 +1,30 @@
 #!/usr/bin/env python3
 """Stop hook: governance-aware session completion reminder.
 
-Detects whether the session involved code changes, merges, or deploys,
-and reminds the agent about specific post-merge governance skills.
+Delegates git state detection to git_checks and admin completion
+logic to stop_checks. Orchestrates blocking decisions and messages.
 """
 import json
 import os
-import subprocess
 import sys
 from pathlib import Path
 
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
 
-def detect_session_signals(cwd: str) -> list[str]:
-    """Detect what happened in this session by checking git state."""
-    signals = []
-    try:
-        # Check for recent commits (last 2 hours) that suggest a merge/deploy happened
-        result = subprocess.run(
-            ["git", "log", "--oneline", "--since=2 hours ago", "--no-walk", "HEAD"],
-            capture_output=True, text=True, cwd=cwd, timeout=5
-        )
-        if result.returncode == 0 and result.stdout.strip():
-            signals.append("recent-commits")
-
-        # Check if any tracked files were modified in this session
-        result = subprocess.run(
-            ["git", "diff", "--name-only", "HEAD~1", "HEAD"],
-            capture_output=True, text=True, cwd=cwd, timeout=5
-        )
-        if result.returncode == 0:
-            changed = result.stdout.strip().split("\n")
-            changed = [f for f in changed if f]
-            if any(f.endswith(".sh") or f.endswith(".js") or f.endswith(".py") for f in changed):
-                signals.append("code-changed")
-            if any("README" in f or "CHANGELOG" in f for f in changed):
-                signals.append("docs-updated")
-            if any(f.startswith("vscode-extension/") for f in changed):
-                signals.append("extension-changed")
-    except Exception:
-        pass
-    return signals
+from git_checks import detect_session_signals, detect_uncommitted_changes
+from governance_state import ensure_state, reset_on_branch_change, save_state
+from stop_checks import (
+    check_admin_ops, check_uncommitted, post_merge_messages, wiki_pending_message,
+)
+from client_arbitration_guard import (
+    adjudication_redirect,
+    classify_internal_conflict,
+    detect_client_arbitration,
+    emit_incident,
+    extract_assistant_text,
+)
 
 
 def main() -> int:
@@ -52,25 +37,100 @@ def main() -> int:
         return 0
 
     cwd = payload.get("cwd") or os.getcwd()
+    state = ensure_state(cwd)
+    import subprocess
+    try:
+        branch = subprocess.check_output(["git","rev-parse","--abbrev-ref","HEAD"],
+                                         cwd=cwd, text=True, stderr=subprocess.DEVNULL).strip()
+    except Exception:
+        branch = None
+    state = reset_on_branch_change(cwd, branch)
     signals = detect_session_signals(cwd)
+    uncommitted = detect_uncommitted_changes(cwd)
+    flags = state.get("flags", {})
+    ops = state.get("admin_ops", {})
+    roles = state.get("roles", {})
+    repo_type = state.get("repo_type", "generic")
 
-    if "code-changed" in signals or "extension-changed" in signals:
-        msg = (
-            "Post-merge governance checklist — verify before ending:\n"
-            "1. CHANGELOG updated for all shipped behavioral changes\n"
-            "2. README/docs reflect new behavior (kill hierarchy, commands, settings)\n"
-            "3. repo-profile-governance: community health files, metadata, templates\n"
-            "4. docs-drift-maintenance: no stale docs contradicting new behavior\n"
-            "5. Learnings entry if significant discovery was made\n"
-            "If these were already completed or are not applicable, proceed."
+    messages = []
+    block_reason = None
+
+    assistant_text = extract_assistant_text(payload)
+    violations = detect_client_arbitration(assistant_text)
+    if violations:
+        # #3749: ACTIVELY redirect a non-carve-out client-defer into the free
+        # cross-model panel instead of only logging a passive block.
+        redirect = adjudication_redirect(assistant_text, violations)
+        emit_incident(
+            "client-defer-routed-to-adjudication",
+            evidence=[redirect["subclass"], *violations],
         )
+        block_reason = (
+            "Stop blocked: non-carve-out client-defer — route to cross-model adjudication."
+        )
+        messages.append("CLIENT-DEFER GUARDRAIL — " + redirect["directive"])
+
+    if not block_reason:
+        block_reason, msg = check_uncommitted(uncommitted, roles)
     else:
-        msg = (
-            "Before ending: confirm claimed checks/releases are evidence-backed "
-            "and docs are synchronized where behavior/config changed."
+        msg = None
+    if msg:
+        messages.append(msg)
+
+    conflict = classify_internal_conflict(uncommitted)
+    if conflict.get("type") != "none":
+        emit_incident(
+            "internal-conflict-auto-resolution-required",
+            evidence=[conflict["type"], *conflict.get("files", [])[:5]],
+            severity="medium",
+        )
+        if not block_reason:
+            block_reason = "Stop blocked: unresolved internal conflict requires deterministic operator resolution."
+        policy = " | ".join(conflict.get("policy", []))
+        messages.append(
+            f"INTERNAL-CONFLICT POLICY ({conflict['type']}): {policy}"
         )
 
-    out = {"systemMessage": msg}
+    if not block_reason:
+        # #3266/#3569: a clean report-only session (lane:research / lane:docs-research /
+        # lane:docs-only) is PR-less/merge-less by design — require ZERO Admin ops so a lingering
+        # code_touched flag cannot manufacture a phantom Admin nag. A dirty tree removes the
+        # exemption (nothing-to-merge is the whole justification).
+        report_only_clean_exempt = False
+        try:
+            from pretool_guard import (
+                active_ticket_is_research_lane, active_ticket_is_docs_lane)
+            report_only_lane = (
+                bool(active_ticket_is_research_lane(state, cwd))
+                or bool(active_ticket_is_docs_lane(state, cwd)))  # #3569
+            report_only_clean_exempt = report_only_lane and not uncommitted
+        except Exception:
+            report_only_clean_exempt = False  # fail-safe: fall back to the standard Admin-op gate
+        block_reason, msg = check_admin_ops(
+            flags, ops, roles, repo_type, uncommitted, report_only_clean_exempt)
+        if msg:
+            messages.append(msg)
+
+    messages.extend(post_merge_messages(signals, bool(messages), ops))
+    wiki_msg = wiki_pending_message(cwd, flags, ops)
+    if wiki_msg:
+        messages.append(wiki_msg)
+
+    drift = state.get("drift", {})
+    total_c = drift.get("commits", 0)
+    if total_c > 0:
+        rate = (total_c - drift.get("commits_with_ticket", 0)) / total_c * 100
+        messages.append(f"📊 Drift score: {rate:.0f}% ticketless ({total_c} commits this session).")
+
+    out = {"systemMessage": "\n\n".join(messages)}
+    if block_reason:
+        out["decision"] = "block"
+        out["reason"] = block_reason
+
+    if not block_reason:
+        roles["consultant"] = True
+        save_state(state)
+
     print(json.dumps(out))
     return 0
 

--- a/instructions/github-governance.instructions.md
+++ b/instructions/github-governance.instructions.md
@@ -15,17 +15,26 @@ applyTo: "**"
 ## Commits and PR titles — Conventional Commits
 
 - Format: `type(scope): imperative description` ≤72 chars.
-- Allowed types: `feat` `fix` `chore` `content` `perf` `refactor` `docs` `style` `test`.
+- Allowed types: `feat` `fix` `chore` `content` `perf` `refactor` `docs` `style` `test` `skill` `hotfix`. (Canonical 11-type set; source of truth: `scripts/global/conventional-commits-enum.js` per #2304.)
 - Branch naming: `<type>/<issue-number>-<short-slug>` (e.g. `fix/5-nav-contrast`).
 
 ## Ticket lifecycle gates
 
 - Every change needs a linked issue with taxonomy label (`type:*`), priority label, domain label, milestone, and project assignment before coding starts.
-- PR requires `Closes #N`, milestone, labels, and gate-suite evidence.
+- PR body MUST include `Refs #N` for issue linkage AND one of the following merge-evidence
+  forms (per Epic #2295 Phase-1 P1.3):
+  - **Preferred**: `merge-evidence-deferred-final: #N` — satisfies `merge-evidence-pr-gate`
+    without auto-closing the issue on merge. Consultant retains explicit terminal-finalize
+    authority and closes via `gh issue close #N` after `CONSULTANT_CLOSEOUT`.
+  - **Backward-compat**: `Closes #N` (or `Fixes #N` / `Resolves #N`) — still accepted;
+    triggers GitHub auto-close on merge.
+  - Author the linkage on its own lines per the canonical block; gates resolve the accountable
+    ticket via `scripts/global/linkage-resolver.js` (prefer Closes / deferred-final, then the
+    first line-anchored `Refs #N`; `Refs Epic #N` is excluded). See
+    `docs/howto/canonical-linkage-block.md` (#1614).
 - Issues must include: problem/objective, expected outcome, acceptance criteria.
 - Large work is decomposed with sub-issues and `blocked by` / `blocking` dependencies.
 - Templates required: at minimum bug, task, and epic forms. `blank_issues_enabled: false` in config.yml.
-- For detailed lifecycle execution, if available, invoke the `github-ticket-lifecycle-orchestrator` skill.
 
 ## Review and merge gates
 
@@ -34,19 +43,17 @@ applyTo: "**"
 - All review conversations resolved.
 - Rulesets/branch protection requirements satisfied.
 - Merge method follows repo policy.
-- For detailed review/merge administration, if available, invoke the `github-review-merge-admin` skill.
 
-## Actions & OpenSSF security baseline
+## Actions security baseline
 
-- `GITHUB_TOKEN`: default to read-all permissions; grant write only per-job when required.
-- Third-party actions: pin to full commit SHA, not tags.
+- `GITHUB_TOKEN`: default to read permissions; elevate per-job only when required.
+- Third-party actions: pin to full commit SHA where policy requires.
 - Prefer OIDC over long-lived static cloud credentials.
 - CODEOWNERS coverage for `.github/workflows/`.
 - No auto-remediation that broadens permissions.
-- Enable Dependabot alerts, secret scanning, and push protection on every public repo.
-- Add `ossf/scorecard-action` to CI for public repos to track security posture.
-- Private vulnerability reporting enabled via GitHub settings.
-- For detailed Actions hardening, invoke `github-actions-security-hardening` skill.
+- **Label-lint enforcement**: `.github/workflows/label-lint.yml` runs on all `issues`
+  events and enforces ADR-010 label rules (single status, single role, no execution
+  role on terminal closed/backlog items). Violations post a comment and fail the check.
 
 ## Release and incident flow
 
@@ -56,18 +63,32 @@ applyTo: "**"
 - Incident items include severity, impact, owner, and containment plan.
 - Hotfix branch/PR linked to incident issue with validation evidence.
 - Follow-up prevention tickets created before incident closure.
-- For detailed release/incident procedures, if available, invoke the `github-release-incident-flow` skill.
 
 ## Project linkage
 
 - Project items have status, priority, iteration, and owner fields populated.
 - Issue ↔ branch and issue ↔ PR linkage maintained in the Development panel.
 - Built-in workflows: auto-add, status sync, auto-archive configured where available.
-- For detailed Agile linkage setup, if available, invoke the `github-projects-agile-linkage` skill.
 
 ## Capability-first routing
 
-- Before recommending rulesets, merge queue, or plan-sensitive features, run `github-capability-resolver` to verify availability by plan/visibility/owner type.
-- If available, route GitHub workflow governance requests through `github-ops-tree-router`.
-- Use `github-ops-excellence` as the policy catalog overlay for calibrating strictness.
-- For ruleset design/migration, invoke `github-ruleset-architecture` skill.
+- Before recommending rulesets or plan-sensitive features, run `github-capability-resolver` to verify availability.
+- Route workflow governance requests through `github-ops-tree-router`; invoke `github-ruleset-architecture` for ruleset design.
+- For workflow automation that compares actors, apply Team&Model-first identity resolution per `instructions/team-model-in-workflows.instructions.md`.
+
+## MCP server as standard tool surface
+
+The official GitHub MCP server (`github/github-mcp-server`) is the preferred
+GitHub tool surface across Claude Code / Copilot / Codex teams. MCP tools cover
+Issues, Pull Requests, Discussions, Projects v2, Sub-issues, Actions, and
+Repositories. Standardizing on MCP eliminates per-team REST/CLI adapter drift.
+
+- **Activation**: each team's skill MAY load the MCP server before composing
+  baton artifacts. `gh` CLI remains the supported fallback.
+- **Credentials**: MCP server requires a `GITHUB_TOKEN`. Every operator using
+  `gh` CLI already has one; no new credential surface.
+- **G5 portability**: integral to harness goals; air-gapped operators have no
+  GitHub access at baseline (consistent constraint, not an MCP gap).
+- **Opt-out**: `MEGINGJORD_MCP_DISABLED=1` (parity with `MEGINGJORD_HAMR_DISABLED`).
+  Skills detecting the opt-out fall back to `gh` CLI without behavior change.
+- **Adoption guide**: `docs/howto/mcp-server-adoption.md`.

--- a/instructions/global-standards.instructions.md
+++ b/instructions/global-standards.instructions.md
@@ -5,15 +5,122 @@ applyTo: "**"
 ---
 # Global Engineering Standards
 
+## Ticket-first governance
+
+- No code or config work without a linked GitHub issue (ticket-first gate).
+- Every commit message must reference `#N` (issue number). **IT-ops bypass (#2142)**: maintenance commits that touch tracked files but don't warrant Agile baton workflow (model pulls, fleet config updates, local-only environment changes) may set env var `MEGINGJORD_IT_OPS=1`, include literal `[it-ops]` in the commit subject, OR use `chore(it-ops):` Conventional-Commits prefix. The bypass emits an `allow` advisory naming the matched marker (not silent). IT role scope, boundary, and auto-auth contract: `skills/role-it-execution/SKILL.md` (#2318).
+- Branch naming: `<type>/<issue#>-<slug>` (e.g., `feat/62-multi-ticket-baton`).
+- Research tickets skip branching; findings posted as ticket comments.
+- Pull latest `main` into feature branch before creating PR.
+
+## Engineering standards
+
 - Prefer root-cause fixes over detection-only band-aids.
 - Prefer prevention over reaction: local guardrails first, CI backstops second.
 - Never claim build, test, release, or publish success without explicit evidence.
 - Keep changes minimal, localized, and reversible.
 - Preserve public APIs unless change scope explicitly requires API updates.
+- When behavior or interfaces change, update documentation in the same change.
 - Never expose secrets in repository files, packaged artifacts, logs, or generated examples.
-- Before packaging/publishing, verify exclude rules (`.vscodeignore`, `.npmignore`, artifact manifests) block secret-bearing files. Run manifest listing commands (`vsce ls`, `npm pack --dry-run`) as preflight.
+- Before packaging/publishing, verify exclude rules block secret-bearing files.
 - Use placeholders in docs and examples — never live tokens, keys, or credentials.
-- Prevention first, detection second: local guardrails (exclude rules, pre-commit hooks) before CI scanning backstops.
-- For versioned artifacts, enforce a single source of truth and verify version consistency (tag = manifest = changelog) before release.
+- For versioned artifacts, enforce version consistency (tag = manifest = changelog).
 - Use deterministic checks and objective pass/fail gates whenever possible.
-- If evidence is incomplete, state uncertainty and gather missing evidence before finalizing.
+- If evidence is incomplete, state uncertainty and gather missing evidence.
+
+## Deferred-finalize merge-evidence contract (Epic #2295 P1.3)
+
+PR bodies MUST include merge evidence for their linked issue. Two accepted forms:
+
+- **Preferred** — `merge-evidence-deferred-final: #N`: satisfies `merge-evidence-pr-gate`
+  WITHOUT triggering GitHub auto-close on merge. Consultant retains explicit terminal-finalize
+  authority and closes the issue via `gh issue close #N` after posting `CONSULTANT_CLOSEOUT`.
+- **Backward-compat** — `Closes #N` (or `Fixes #N` / `Resolves #N`): still accepted; triggers
+  GitHub auto-close on merge. Use only when Consultant-explicit-close is not required.
+
+Carve-out rationale: the deferred-finalize form resolves the PR-template vs merge-evidence-gate
+conflict (template says "use Refs, not Closes"; gate previously required Closes). Registry entry:
+`governance-carve-outs/index.md` entry `closes-vs-refs-deferred-final-carveout`.
+
+## Admin-merge bypass exception (Epic #2517)
+
+An `--admin` / branch-protection-bypass merge (a PR merged without all required checks green or
+required review met) MUST carry a formal exception, else it is a G1 governance violation:
+a `merge-bypass:admin-exception` label on the linked issue, OR a `BLOCKER_NOTE` in the PR body
+with `bypass_reason:` and `approver:` fields. Enforced post-merge by `merge-bypass-gates.yml`
+(`scripts/global/megalint/admin-merge-exception.js`). Relatedly, a multi-close PR that closes
+any issue **as cancelled** requires a per-issue `CANCELLATION: <reason>` comment
+(`batch-cancel-evidence.js`); batch completions keep the `resolved as part of batch with #N` form.
+
+## Goal-lens decision lint (required)
+
+- Apply this priority order to all governed decisions:
+	`G1 Governance > G2 Quality > G3 Zero Cost > G4 Privacy & Security > G5 Portability > G6 Resilience > G7 Throughput > G8 Observability > G9 Interoperability > G10 Maintainability`.
+- **Operator autonomy (cross-cutting, always-on principle — Epic #3391, not a ranked goal):** resolve
+	reversible / low-risk decisions autonomously (free cross-model panel, never a bare client prompt);
+	reach the human only at the 4 retained carve-outs (design / UAT / irreversible / security-weakening,
+	per `config/retained-human-touchpoints.json`); autonomy is HARD-subordinate to C-G1 (Governance) and
+	C-G4 (Privacy & Security); log the autonomy-vs-escalate decision (G8).
+- When tradeoffs occur, explicitly justify why a lower-priority goal overrides a higher one.
+- Keep the justification short and evidence-based in ticket comments, PR body, or closeout notes.
+
+## Canonical-main checkout policy (#2107)
+
+The main checkout (`${HOME}/devenv-ops/`) is canonical-only during sessions. Per Epic #2091 Phase-0 synthesis (`wiki/wisdom/project/research/harness-state-isolation.md` Fix #3):
+
+- **Writes permitted**: ONLY to paths matching `.gitignore` patterns (per-operator config: `.env`, `.env.local`, `.envrc`, `.npmrc`; tooling artifacts: `node_modules`, `dist`, `.cache`, `tmp`, `.dashboard`, `.log4brains`, etc.)
+- **Writes rejected**: tracked files (the codebase); branch switches off `main`; commits; `git stash` on tracked changes; `git worktree add` inside main checkout's working tree
+- **Enforcer**: `hooks/scripts/canonical_main_enforcer.py` invoked by `pretool_guard.py` (rejects deny-decision with redirect-to-worktree message)
+
+**Worktree pattern**: all team work happens in `${HOME}/devenv-ops-<team-or-ticket>/` worktrees. The main checkout is a canonical reference, not a workspace.
+
+**2026 secrets caveat**: industry is migrating secrets out of `.env` toward workload-identity (Bitwarden Secrets Manager, Infisical, Zylos). As Megingjord adopts a secrets manager, the `.gitignore`-allowlist should narrow.
+
+**Sync-direction trap (#2355)**: `scripts/sync.sh` copies `~/.copilot/ -> checkout` (the inverse of `scripts/deploy.sh`). Running it from canonical main while `~/.copilot/` is stale silently regresses tracked files to pre-merge content (root cause of #2355: 16 files reverted at 2026-05-27 22:14:10 across a single sync run, undoing merged PRs #2304 + #2308). The enforcer at `canonical_main_enforcer.py` intercepts Claude Code Edit/Write tool invocations but does NOT see shell-level `cp`/`rsync` inside script bodies. The shell-script blind spot is closed for `sync.sh` specifically: when invoked from canonical main without `--allow-canonical-write`, it exits 2, emits a v3 incident to `~/.megingjord/incidents.jsonl` (pattern_id `sync-sh-reverse-direction-regresses-main`), and prints a redirect to `npm run deploy:apply` (forward direction) or a worktree (for genuine inverse-reload use). Other inverse-direction scripts must adopt the same guard pattern; the blind spot is closed PER-SCRIPT, not class-wide. Coverage: `tests/sync-canonical-main-refuse.spec.js` (6 cases: refuse / JSONL-emit / override-dry-run / override-real-write / worktree / dry-run).
+
+## Cross-team GitHub tool surface
+
+- Default to the official GitHub MCP server (`github/github-mcp-server`) for
+	cross-team GitHub interactions. Falls back to `gh` CLI when MCP unavailable
+	or when `MEGINGJORD_MCP_DISABLED=1` is set.
+- See `instructions/github-governance.instructions.md` for the full contract
+	and `docs/howto/mcp-server-adoption.md` for the operator guide.
+
+## Decisional vs. actionable (Discussions vs. Issues)
+
+- **Issues**: actionable work with concrete deliverable + acceptance criteria.
+- **Discussions**: decisional questions, open design exploration, cross-team
+	protocol debates, tooling research — anything without a concrete AC yet.
+- When a Discussion crystallizes into a deliverable, convert it to an Issue
+	via `gh discussion view N --json` + `gh issue create`. Keep the Discussion
+	link in the Issue body so decisional rationale is preserved.
+- See `docs/howto/discussions-vs-issues.md` for category catalog and examples.
+
+## Codified rules-of-thumb (Epic #2399 AC3)
+
+Rules-of-thumb learned through real harness failures, promoted from operator-local
+memory to the canonical `instructions/` surface so **every** runtime (Copilot,
+Claude Code, Codex, Antigravity) inherits them — not just the operator holding the
+memory files. Each row points to the **verified** canonical home and its real
+disposition. `status` is honest per G1 (never claim "codified" for a rule that is
+still memory-only — the #1617 AC-wording-vs-shipped trap):
+
+- `codified` — the rule is stated in a resident/on-demand instruction file.
+- `documented-elsewhere` — the rule lives in a `docs/howto/` recipe or wiki page.
+- `memory-only` — promotion pending; the rule is still only in operator memory.
+
+| Rule-of-thumb | Canonical location | Status |
+|---|---|---|
+| Post all four baton artifacts **before** `gh pr create` | `role-baton-routing.instructions.md` §"Validation evidence — recent practice" | codified |
+| Consultant emits Tier-3 on a post-implementation G1–G9 goal violation | `workflow-resilience.instructions.md` §"Tier 3 — Consultant goal-failure escalation" | codified |
+| Signer aliases derive deterministically from team + model + role (never a default seed) | `team-model-signing.instructions.md` §"Alias derivation" | codified |
+| Client is design + UAT only — never route dev-flow questions to the client | `operator-identity-context.instructions.md` §"Core rules" (rules 2–3) | codified |
+| No calendar/"N-day soak" thresholds in agentic governance — use velocity-relative + replay-eval | `test-methodology-matrix.instructions.md` §"Stress promotion model"; `programmatic-governance.instructions.md` §Composition (Epic #1771) | codified |
+| `sync.sh` copies runtime **into** the checkout (inverse of `deploy.sh`); a stale runtime silently regresses tracked files | `global-standards.instructions.md` §"Canonical-main checkout policy" → Sync-direction trap (#2355) | codified |
+| Features use the optimal resource when available, fall back to the baseline tier when absent (optimal-with-fallback) | `harness-goals.instructions.md` §"Tier-graceful degradation" | codified |
+| Baton-governance regexes match the **first** `Team&Model:` / `role:NAME` / artifact string in a comment — prose usages pollute them; hyphenate in prose | operator memory (`feedback_*_prose_collision`); only a passing cross-ref in `programmatic-governance.instructions.md` §Composition — no canonical instruction home yet | memory-only |
+
+Source triage: `research/operator-memory-promotion-audit-2026-05-30.md` (Phase-0 #2413) —
+42 memory files scored on scope / type / incident-prevention; the 8 promotion candidates above
+plus 6 recovery recipes (routed to `docs/howto/`, not policy). When a `memory-only` row is
+promoted, flip its `status` here and update the originating memory file to point at the canonical location (Epic #2399 AC4).

--- a/instructions/operator-identity-context.instructions.md
+++ b/instructions/operator-identity-context.instructions.md
@@ -6,16 +6,16 @@ applyTo: "**"
 
 # Operator Identity Context
 
-Load and apply the `operator-identity-context` skill at the start of every task.
-
 ## Core rules (always active)
 
-1. **You are the operator.** You own manager, collaborator, admin, and consultant responsibilities. State management and single-thread execution routing are exclusively governed by the `role-baton-routing` instructions.
+1. **You are the operator.** You own manager, collaborator, admin, and consultant responsibilities, but execute them in a **single-thread baton sequence**:
+   - Manager (scope + plan + gates)
+   - Collaborator (implement + validate)
+   - Admin (git/release/runtime ops)
+   - Consultant (independent critique and risk review)
+   At most one role is active at a time.
 
-2. **The user is the client.** Curtis / Hayden is consulted only for:
-   - Design direction (colors, layout, copy preferences)
-   - UAT visual confirmation (does it look right?)
-   That is the complete list. Nothing else requires user involvement.
+2. **The user is the client.** Consult only for design direction and UAT visual confirmation. Nothing else requires user involvement.
 
 3. **Never ask the user to manually do anything.** If an automation gap exists, close it before declaring the task done. Acceptable research order:
    - Check existing `scripts/` for established patterns
@@ -24,14 +24,38 @@ Load and apply the `operator-identity-context` skill at the start of every task.
    - Build Playwright UI automation if no API exists
    - Only if a step is genuinely impossible to automate (hardware 2FA, anti-bot CAPTCHA with no bypass) — state that with explicit evidence and reduce the user's action to the absolute minimum
 
-4. **Use repository/environment overlays for platform specifics.**
-   - Treat global instructions as baseline.
-   - Use repository-local instruction files and skills for machine/project specifics.
-   - If global and repository instructions differ, apply repository instructions for that workspace.
+4. **Use repository/environment overlays for platform specifics.** Global instructions are baseline; repository-local instructions win on conflict.
 
 5. **Role router requirement:**
-   - For non-trivial tasks, invoke `role-baton-orchestrator` first.
-   - Use role skills for handoff clarity: `role-manager-execution`, `role-collaborator-execution`, `role-admin-execution`, `role-consultant-critique`.
+   - Invoke `role-baton-orchestrator` at task start. Skip only for trivial tasks (single Q&A, read-only lookup, no state-changing tool calls).
+   - Each role emits a named handoff artifact (`MANAGER_HANDOFF`, `COLLABORATOR_HANDOFF`, `ADMIN_HANDOFF`, `CONSULTANT_CLOSEOUT`) before the next role begins.
 
-6. **Self-anneal check:** If you catch yourself writing "you will need to…", "please manually…", or "Hayden must…" — stop, invoke the research protocol from the `operator-identity-context` skill, and find the automation path instead.
+6. **Self-anneal check:** If you catch yourself writing "you will need to…", "please manually…", or "the user must…" — stop, invoke the research protocol from the `operator-identity-context` skill, and find the automation path instead.
 
+## Role taxonomy disambiguation
+
+**Operator** is a meta-term for the AI agent (Claude Code, Codex, etc.) that executes
+the four baton roles (Manager, Collaborator, Admin, Consultant) in single-thread
+sequence. It is NOT a distinct role in the 7-role taxonomy.
+
+The canonical 7-role set is enumerated in
+`instructions/role-baton-routing.instructions.md` §"Role Taxonomy". The full list:
+Manager / Collaborator / Admin / Consultant / IT / Red-Team / Client.
+Guest-Collaborator is reserved but not active.
+
+When reading baton artifacts: "operator" in prose refers to the AI agent entity,
+never to a baton-step role. Use the exact role name (e.g. "the admin role") when
+referring to a specific baton position.
+
+## Self-posting the approving CONSULTANT_CLOSEOUT is autonomously-resolvable (#3714)
+
+The operator owns all four baton roles (rule 1), so it authors the Consultant's
+`CONSULTANT_CLOSEOUT` itself. When that closeout carries a valid `cross_family_verdict`
+backed by a **verified** cross-family consensus receipt (`governance/cross-family-consensus.jsonl`,
+>=2 non-authoring families each able to REJECT), independence is satisfied by the receipt —
+**not** by asking the client. "May I self-post the approving closeout?" is therefore a
+**routine, autonomously-resolvable** decision (route the legitimacy question to the free
+cross-family panel / `fleet-decision-oracle`), NOT a design/UAT/irreversible/security-weakening
+carve-out. Escalating it to the client is the exact rule-2/rule-3 violation captured in the #1889 incident. A same-family closeout with **no** verified receipt still blocks
+(anti-self-approval preserved). Full contract: `feature-completion-governance.instructions.md`
+§"Self-posted CONSULTANT_CLOSEOUT — decision routing (#3714)".

--- a/instructions/playwright-mcp-low-resource.instructions.md
+++ b/instructions/playwright-mcp-low-resource.instructions.md
@@ -8,7 +8,7 @@ When the task involves Playwright MCP, browser automation, visual QA, screenshot
 
 1. Apply the `playwright-vision-low-resource` skill first.
 2. Run preflight before browser actions:
-   - `~/.gemini/antigravity/skills/playwright-vision-low-resource/scripts/preflight-playwright-mcp.sh`
+   - `~/.copilot/skills/playwright-vision-low-resource/scripts/preflight-playwright-mcp.sh`
 3. Use bounded retries:
    - Maximum 2 retries for browser-context failures.
 4. Prefer local constrained profile by default:

--- a/instructions/release-docs-hygiene.instructions.md
+++ b/instructions/release-docs-hygiene.instructions.md
@@ -5,25 +5,27 @@ applyTo: "**"
 ---
 # Release and Docs Hygiene
 
-- Before any release action, verify version consistency between tag, manifest, and changelog. Invoke `release-version-integrity` skill for systematic drift detection.
-- Audit packaged artifact file lists before publish when packaging tools support manifest listing.
-- Treat `.env`, key material, token files, and private config as non-distributable by default. Invoke `secret-exposure-prevention` skill when editing publish/package workflows.
-- Run `docs-drift-maintenance` skill after any change to commands, CLI flags, configuration files, APIs, workflows, or user-facing behavior.
-- Docs updates must ship with changes — not as follow-up.
-- Map each changed surface to impacted docs (README, CHANGELOG, operational docs, runbooks).
-- Keep wording precise, testable, and user-actionable. Verify docs match actual behavior after updates.
-- Prefer automated versioning flows over manual multi-file version edits.
-- Keep release notes factual and traceable to merged changes.
-
 ## Post-Merge / Post-Deploy Governance Checklist (Mandatory)
 
 After every PR merge or deployment that changes user-facing behavior, run these governance steps before considering the task complete:
 
-1. **CHANGELOG**: Add an entry for every shipped behavioral change. Extension changelog (`vscode-extension/CHANGELOG.md`) covers both extension and daemon changes.
+1. **CHANGELOG fragment**: For every shipped behavioral change, create a per-ticket fragment at `.changes/unreleased/<N>.md` (where `N` is the GitHub issue number). Aggregator (`node scripts/global/changelog-aggregate.js`) prepends fragments into `CHANGELOG.md` at release time. Direct edits to `CHANGELOG.md` remain valid (back-compat) but the fragment path is preferred — it eliminates merge conflicts when multiple PRs ship in parallel. For trivial PRs warranting no changelog entry, include `[skip-changelog]` in the PR description. Extension changelog (`vscode-extension/CHANGELOG.md`) covers both extension and daemon changes. See `docs/howto/changelog-fragments.md` for the author guide.
 2. **README sync**: If the change adds, removes, or modifies user-visible behavior (kill hierarchy, commands, settings, protection rules), update both `README.md` and `vscode-extension/README.md`.
 3. **Profile governance**: Run the `repo-profile-governance` skill to audit community health files (SUPPORT.md, CONTRIBUTING.md, CODE_OF_CONDUCT.md, SECURITY.md), metadata (description, topics, homepage), and contribution surfaces (templates, CODEOWNERS).
 4. **Docs drift**: Run the `docs-drift-maintenance` skill to detect stale documentation that contradicts the new behavior.
 5. **Learnings**: If the change revealed a significant discovery, add an entry to `docs/workflow/learnings.md`.
 6. **Release integrity**: If the merge changes extension or package behavior, run `release-version-integrity` to validate tag/manifest/changelog alignment, then publish the new version.
+7. **Artifact attestation**: Tag-triggered releases MUST produce both cosign-bundle signature AND GitHub Artifact Attestation (Sigstore-backed; via `actions/attest-build-provenance`). C13 (#999) enables the parallel attestation signal alongside the existing cosign path.
 
-Do not consider a PR merge or deployment task complete until steps 1-6 are explicitly addressed (either completed or confirmed not applicable).
+Do not consider a PR merge or deployment task complete until steps 1-7 are explicitly addressed (either completed or confirmed not applicable).
+
+## Tech-Writer sub-phase (lane:code-change)
+
+`COLLABORATOR_HANDOFF` for `lane:code-change` tickets MUST include a `doc-coverage:` block
+declaring each required surface as `UPDATED: <path>` or `N/A: <surface> — <reason>`.
+Required surfaces per `area:*` label are defined in `config/doc-coverage-matrix.yml`.
+Validator: `scripts/global/megalint/doc-coverage.js`. Escape hatch: `DOC_COVERAGE_GATE_ADVISORY=1`.
+
+## Merge-time documentation governance
+
+For the operator-facing runbook describing how Epic #2148 children (C0+C1+C2+C3+C5+C7) compose into the four-surface merge-time documentation governance system, see [docs/howto/merge-time-doc-governance.md](../docs/howto/merge-time-doc-governance.md).

--- a/instructions/repo-health-onboarding.instructions.md
+++ b/instructions/repo-health-onboarding.instructions.md
@@ -39,28 +39,27 @@ Files live in repo root or `.github/`. Missing items are prioritized:
 - Classify repository by primary app type (`website-static`, `web-app`, `library-sdk`, `infra-automation`) before applying standards.
 - Apply core-baseline controls, then primary-type controls, then relevant overlays (`security`, `collaboration`, `release`, `observability`).
 - Prefer the smallest correct standards stack over over-engineered policy.
-- For detailed routing, if available, invoke `repo-standards-router` skill.
-- For new/uninitialized repos, invoke `repo-onboarding-standards` skill.
 
 ## Governance audit triggers
 
-Run `repo-profile-governance` skill when:
-- Starting a new session in any repository (quick health check).
-- Before any public release.
-- When community health gaps are suspected.
+Run `repo-profile-governance` skill at session start, after behavior-changing merges/deploys, before releases, and when community health gaps are suspected.
 
 ## Repository structure conventions
 
-- On new repos or restructuring, if available, invoke `repo-structure-conventions` skill.
 - Every repo follows a universal root layout: README, LICENSE, CHANGELOG, .gitignore, .github/, docs/, scripts/, test/.
 - CHANGELOG.md follows [Keep a Changelog](https://keepachangelog.com/) format: Added, Changed, Deprecated, Removed, Fixed, Security.
 - Build artifacts are isolated via .gitignore (and .vscodeignore / .npmignore where applicable).
 - No build outputs (dist/, node_modules/, resources/, *.vsix, __pycache__/) in git history.
 
+## OpenSSF security alignment
 
+- Enable Dependabot alerts, secret scanning, and push protection on every public repo.
+- Add `ossf/scorecard-action` to CI for public repos to track security posture.
+- Pin third-party Actions to full commit SHA, not tags.
+- Workflow `permissions` block defaults to `read-all`; grant write only per-job.
+- Private vulnerability reporting enabled via GitHub settings.
 
 ## Consistency across repos
 
-- Critical standards are consistent across all managed repositories.
-- Deviations are documented and intentional, not accidental drift.
+- Critical standards are consistent across all managed repositories; deviations are documented and intentional.
 - Weekly `profile-weekly-check` mode available for recurring hygiene regression detection.

--- a/instructions/role-baton-routing.instructions.md
+++ b/instructions/role-baton-routing.instructions.md
@@ -1,35 +1,411 @@
 ---
 name: Role Baton Routing
-description: Enforce single-thread role handoff across Manager -> Collaborator -> Admin -> Consultant. Prevent concurrent role mixing and require explicit handoff artifacts.
+description: "v2.0 — Single-thread role handoff with GitHub Projects integration, typed collaborators, zero null-role states."
 applyTo: "**"
 ---
 
-# Role Baton Routing
+# Role Baton Routing (v2.0)
 
-For non-trivial tasks, execute work through a single active role at a time:
+The GitHub issue **is** the baton. One active role at a time.
+Execution `role:*` labels are present only on active, role-owned states.
+Terminal states do not carry execution roles.
 
-1. **Manager**: scope, constraints, acceptance criteria, gate plan.
-2. **Collaborator**: implementation and validation.
-3. **Admin**: operational execution (services, git/PR/release ops).
-4. **Consultant**: independent critique and residual-risk assessment.
+Authoritative board: **Megingjord Harness Board** (GitHub Projects).
+Baton view filter: `status:triage,ready,in-progress,testing,review` (backlog/done/cancelled/dormant/deferred hidden from active baton view).
 
-## Hard rules
+## Role Taxonomy (7-role canonical set, Epic #2299)
 
-- No concurrent role execution.
-- Do not skip a role when its scope is applicable.
-- Emit a short handoff artifact at each transition.
-- If a role cannot proceed due to missing evidence, stop and request the missing evidence from tooling/research (not from the user by default).
+The harness recognizes seven named roles. Operator is a meta-term (see
+`instructions/operator-identity-context.instructions.md`), not an eighth role.
 
-## Skill mapping
+| Role | Scope | GitHub baton label |
+|---|---|---|
+| Manager | Scope, AC authoring, baton routing, Epic oversight | `role:manager` |
+| Collaborator | Implementation, deliverable production, test authoring | `role:collaborator` |
+| Admin | Git/release ops, merge, runtime sync, publish | `role:admin` |
+| Consultant | Independent critique, rubric scoring, closeout authority | `role:consultant` |
+| IT | Fleet hardware + service setup/config (no GitHub workflow) | `role:it` |
+| Red-Team | Adversarial cross-family review; structured hallucination audit | `role:red-team` |
+| Client | Design direction + UAT confirmation; overrides Consultant carve-outs | `role:client` |
 
-- Manager: `role-manager-execution`
-- Collaborator: `role-collaborator-execution`
-- Admin: `role-admin-execution`
-- Consultant: `role-consultant-critique`
-- Orchestration: `role-baton-orchestrator`
+**Guest-Collaborator (RESERVED)**: placeholder for non-adversarial external
+contributions (fleet-coding-local dispatch, cross-team feature contributions,
+external human wiki-ingest) that are NOT adversarial/critique-class. Not
+currently active; use Red-Team for all adversarial/review dispatches (D1,
+Epic #2299). Reserved to prevent taxonomy namespace collision.
 
-## De-duplication boundary
+IT role note: IT scope covers fleet hardware (hosts, Tailscale mesh, Ollama
+models, MCP provisioning) and services (HAMR activation, cron, hook install).
+IT does NOT create tickets, push branches, commit, or comment on issues. The
+`[it-ops]` / `MEGINGJORD_IT_OPS=1` / `chore(it-ops):` bypass markers are the
+documented IT-role escape hatch for the rare tracked-file edit that does not
+warrant a full baton cycle.
 
-- `operator-identity-context` defines authority and automation mandate.
-- Role skills define per-role execution contracts.
-- Domain skills (`repo-standards-router`, `workflow-self-anneal`, release/security/docs skills) remain source of truth for specialized procedures.
+## Status Workflow (11-state taxonomy v1.2, Epic #1828)
+
+```
+Status         Role Label                       Gate / Trigger
+──────────────────────────────────────────────────────────────────────
+backlog        — (Epic: manager)                Created; Epic untouched; child has no parent context yet
+queued         —                                Child of active Epic; awaiting Manager pickup (#1828)
+triage         role:manager                     Manager actively scoping AC + gates
+ready          —                                MANAGER_HANDOFF emitted; awaiting Collaborator pickup
+in-progress    role:collaborator                Implementation active (Epic: role:manager per Rule E3)
+testing        role:admin                       COLLABORATOR_HANDOFF emitted; CI gates running
+review         role:consultant                  ADMIN_HANDOFF emitted; critique + closeout active
+                                                (Epic: role:consultant transient — Rule E2 v2, #1828)
+done           — (terminal)                     CONSULTANT_CLOSEOUT emitted; issue closed
+cancelled      — (terminal)                     Goal invalidated; Manager authority
+dormant        role:manager                     Epic-only: paused; 90d EPIC_REVIEW (Rule E5)
+deferred       role:manager                     Epic-only: blocked, no ETA (Rule E5)
+```
+
+**Single-status invariant**: at any time, a ticket carries **exactly one** `status:*` label. Multi-status carriage is a Rule 1 violation, enforced by label-lint (Epic #1828 AC6).
+
+**Status sub-flow for child tickets of an active Epic**:
+- Independent ticket: `backlog → triage → ready → in-progress → testing → review → done`
+- Child of Epic at `status:backlog`: child stays at `backlog`
+- Child of Epic at `status:in-progress | dormant | deferred`: child progresses `backlog → queued → triage → ready → in-progress → testing → review → done`
+- Transition `backlog → queued` is Manager-initiated when the parent Epic moves out of `status:backlog`. Label-lint emits an advisory comment when this transition is pending.
+
+## Transition Guards
+
+- `backlog → triage`: Manager picks up; applies `role:manager`.
+- `triage → ready`: MANAGER_HANDOFF posted; remove `role:manager` (no role on `ready`).
+- `ready → in-progress`: Collaborator picks up; applies `role:collaborator`.
+- `in-progress → testing`: COLLABORATOR_HANDOFF; all ACs ✅; swap to `role:admin`.
+- `testing → review`: ADMIN_HANDOFF; all gates pass; swap to `role:consultant`.
+- `review → done`: CONSULTANT_CLOSEOUT; remove `role:consultant`; close issue (atomic). Must declare `anneal_tickets_filed: [#N,...] | none` and `mid_flight_flaws:` accounting.
+- `any → cancelled`: Manager authority — remove current `role:*`; post `CANCELLATION: <reason>`; close as "not planned".
+- `in-progress ↔ dormant` (Epic-only): Manager pauses; carries `role:manager` per Rule E2.
+- `in-progress ↔ deferred` (Epic-only): Manager flags external blocker; carries `role:manager`.
+- Manager ticket-health checks, AC edits, and label fixes are out-of-band; no handoff required.
+
+## Gate entry conditions — Admin and Consultant (Refs #1944)
+
+The two most-failure-prone transitions in the baton are `in-progress → testing` (Collaborator → Admin) and `testing → review` (Admin → Consultant). Both gates carry four facets that ALL must hold before the next role may pick up.
+
+### Admin gate (entry to `status:testing`)
+
+| Facet | Requirement |
+|---|---|
+| Trigger artifact | `COLLABORATOR_HANDOFF` comment posted on the linked issue. The comment must carry the four signing fields (`Signed-by`, `Team&Model`, `Role: collaborator`, plus `test_strategy:`) and the per-AC verification block. Validator: `scripts/global/megalint/collaborator-handoff.js`. |
+| Role-label transition | Remove `role:collaborator`; add `role:admin`. Single-role invariant holds at every instant per Rule 1. |
+| Status-label transition | Remove `status:in-progress`; add `status:testing`. Single-status invariant per the §"Single-status invariant" rule above. |
+| Preconditions | (a) ALL declared ACs verified PASS in the COLLABORATOR_HANDOFF per-AC block. (b) `test_strategy` evidence present per `instructions/test-methodology-matrix.instructions.md` — validator `scripts/global/megalint/test-discoverability.js`. (c) Lint clean for the lane (lane:code-change requires `npm run lint` green; lane:docs-research requires `wiki-lint` if wiki touched). |
+
+### Tech-Writer sub-phase (mandatory before posting the-collaborator-handoff per Epic #2148 / #2154)
+
+Before the role-collaborator-label holder posts the-collaborator-handoff, the comment MUST include a doc-coverage block per applicable surface in [config/doc-coverage-matrix.yml](../config/doc-coverage-matrix.yml). For each required + suggested surface the area-label maps to, declare one of:
+
+```
+doc-coverage:
+  UPDATED: <path-or-link> — <one-line summary of update>
+  N/A: <surface> — <reason: out-of-scope | covered-by-sibling-pr | docs-only-no-functional-change>
+```
+
+ADVISORY in first ship (Epic #2148 C1 #2154); the-collaborator-handoff validator (`scripts/global/megalint/collaborator-handoff.js`) parses the block when present and emits an advisory; missing block on lane:code-change emits a warning. Promotion to BLOCKING happens after Epic #2148 close, tracked as a follow-on.
+
+### Consultant gate (entry to `status:review`)
+
+| Facet | Requirement |
+|---|---|
+| Trigger artifact | `ADMIN_HANDOFF` comment posted on the linked issue. Must carry signing fields with `Role: admin`, plus `branch:`, `commit:`, `signer-independence-check: PASS`, and `deploy-runtime-impact:` (or `sync-verification: N/A` per `feature-completion-governance.instructions.md`). Validator: `scripts/global/megalint/admin-handoff.js`. |
+| Role-label transition | Remove `role:admin`; add `role:consultant`. |
+| Status-label transition | Remove `status:testing`; add `status:review`. |
+| Preconditions | (a) Signer-independence: Admin signer alias MUST differ from Collaborator signer alias — validator `scripts/global/megalint/signer-fidelity.js`. (b) ALL required CI checks PASS on the linked PR — observed via `gh pr checks <PR#>` or `live_checks.ci_all_pass()`; pre-merge gate `merge-evidence-pr-gate.js` enforces. (c) PR merged OR merge-evidence-override-approved label present on the linked issue per the merge-evidence batch contract. (d) For lane:code-change touching deployed runtime artifacts: `npm run sync:codex` + `npm run sync:claude` + `npm run hamr:sync-verify` outputs cited per `feature-completion-governance.instructions.md`. (e) **Merge-before-handoff** (#3053, Epic #3051): for lane:code-change, when CI is green and `admin_review_rating >= 93`, the PR MUST be merged before ADMIN_HANDOFF — validator `scripts/global/megalint/admin-merge-precondition.js`. |
+
+### Merge-before-handoff predicate (Epic #3051, Refs #3053)
+
+For `lane:code-change`, when the linked PR is CI-green, the Admin `admin_review_rating` field is present and >= 93, and the PR is NOT yet merged, the `admin-handoff-without-merge` violation fires. Carve-outs:
+
+- **Red CI never bypassed**: a genuinely RED required-CI PR is NEVER flagged — the authoritative CI gate blocks independently; this predicate does not force a bypass.
+- **Baseline-drift override**: an explicit `baseline_drift_override` in admin_ops stays labelled and honoured (per Epic #2517).
+- **Merge-evidence-override**: the `merge-evidence-override-approved` label satisfies the merge step (backward-compat with the merge-evidence batch contract).
+- **Deferred-final honoured**: the deferred-final merge-evidence contract (Epic #2295) is compatible — the predicate checks the prMerged fact, which reflects actual merge state.
+- **Admin owns the merge**: merge authorization is NEVER routed to the client (principle #2578 / AC8). The Admin baton role and close authority are AI-agent roles.
+- **Offline-graceful**: when merge/CI facts are unavailable (GitHub unreachable), the finding degrades to `severity:'advisory'` — the authoritative CI gate blocks when online.
+
+### Validation evidence — recent practice (memory-codified)
+
+The gates above match observed practice in: PR #2045 (Epic #2038 ship; three iterations of cross-family rater + four baton artifacts before PR), PR #2047 (#1943 Three-Wiki synthesis; cross-team file bundling with explicit attribution). Memory anchors: `feedback-all-baton-artifacts-before-pr` (post all four before `gh pr create`; seven consecutive clean ships once applied), `feedback-admin-ci-gate` (Admin verifies ALL required checks green before merge), `feedback-baton-artifacts-in-pr` (PR body must include handoff strings).
+
+## Collaborator role
+
+Per v1.1 taxonomy, the active label is `role:collaborator` (not the older `role:collab-{type}` form). Capability profile is reflected in ticket area labels (`area:scripts`, `area:hooks`, `area:dashboard`, etc.) rather than role-suffix typing. Each Collaborator may have only **1 `in-progress` ticket at a time** (enforced by baton-gates Action).
+
+## Multi-Lane Definition of Done
+
+| Lane         | Work type                      | Role sequence                     | N/A markers                    |
+|--------------|--------------------------------|-----------------------------------|--------------------------------|
+| code-change  | Code, infra, deploy (default)  | Manager→Collab→Admin→Consultant   | none                           |
+| research     | Analysis, wiki — no git branch | Manager→Collab(analyst)→Admin→Consultant | Admin = doc reviewer, not CI |
+| config-only  | Single-value config, no design | Manager→Admin→Consultant          | COLLABORATOR_HANDOFF: N/A      |
+| no-code-remediation | Issue-only drift normalization (no repo edits) | Manager→Consultant | COLLABORATOR_HANDOFF: N/A, ADMIN_HANDOFF: N/A |
+
+Lane set at ticket creation via `lane:*` label and `Lane` Project field. Default: **code-change**.
+
+### No-code remediation lane contract (Refs #2258 #2268)
+
+Eligibility:
+- Ticket drift is limited to issue metadata/evidence normalization (labels, stale advisories, baton artifacts, or closeout evidence) with no source changes.
+- Corrective action is issue/thread state only; no PR diff is needed.
+- Runtime-deploy sync verification is `N/A` because deployed runtime artifacts are untouched.
+
+Exclusions (must escalate to normal baton lane):
+- Any tracked file edit, generated artifact edit, workflow/config change, or test change.
+- Any required CI or validator remediation that needs code/doc changes.
+- Any ambiguity about whether the incident is issue-only versus implementation drift.
+
+Required evidence blocks:
+- `MANAGER_HANDOFF` must state `lane: lane:no-code-remediation`, explicit eligibility rationale, and the exact issue-only actions.
+- `CONSULTANT_CLOSEOUT` must verify each issue-only action completed and include flaw-accounting (`mid_flight_flaws`) plus `verdict` and `rubric_rating`.
+
+False positives and escalation path:
+- If a no-code run reveals required repository edits, Manager posts a correction comment and routes to `lane:code-change` with the standard four-role baton.
+- If stale advisory labels conflict with merged evidence, clear the stale label as issue-only remediation; if merge evidence is absent, escalate to normal baton.
+
+Examples:
+- Valid: remove stale `governance:close-without-merge` on an already-merged closed ticket.
+- Invalid: changing `instructions/**` to satisfy a validator; this is `lane:code-change` (docs/code diff exists).
+
+Operator runbook: `docs/howto/no-code-remediation-workflow.md`.
+
+## Closed-ticket ownership model
+
+Closed tickets do not carry execution `role:*` labels.
+Accountability ownership is historical metadata, not an execution-role label.
+Dashboard/audit views may resolve historical ownership to manager for reporting,
+but this must not re-add a `role:*` label to terminal issues.
+
+### Explicit accountable-team schema (Epic #2345 / design #2346)
+
+Persistent accountability is recorded as an `accountable-team:<team>` label
+(`claude-code | copilot | codex | antigravity`) that is **distinct** from, and
+never shares a namespace with, the transient `role:*` baton label. Unlike
+`role:*`, it persists across **all** states including terminal — so a closed
+ticket answers "who owns this?" without an execution-role label. The team-of-
+record resolves in order: (1) the `accountable-team:*` label, else (2) the team
+in the most recent baton/closeout signing block, else (3) the default manager
+team. Authority: only the Manager or Admin role may set or change it, and never
+as a side effect of a baton transition. Helper: `scripts/global/accountable-team.js`;
+backfill: `scripts/global/accountable-team-backfill.js` (dry-run default).
+See `docs/howto/accountable-team-schema.md`.
+
+## Hard Rules
+
+- Execution `role:*` labels are required for active role-owned states only (`triage`, `in-progress`, `testing`, `review`, and Epic-only `dormant`/`deferred`).
+- Terminal and waiting states (`backlog`, `queued`, `ready`, `done`, `cancelled`) carry no execution `role:*` label, except Epic role exceptions documented in this file.
+- No concurrent role execution on a single ticket.
+- Emit the named handoff artifact before transitioning to the next role.
+- `ADMIN_HANDOFF` must be **independent** of `COLLABORATOR_HANDOFF`. #3532 established the base rule; #3672 (Epic #3679 F2+F3) hardened it against manufactured/forged evidence: independence PASSES **only** via (b) a **VERIFIED cross-family consensus receipt** (`cross_family_receipt:`) OR (c) a cryptographic **authorship attestation**. Everything that is mere prose **FAILS**: (F2) a same-team persona/role-surname split, and a self-asserted `signer-independence-check:` disposition that is **waived / N/A** (reason `independence-self-waived`); (F3) a **bare "different `Team&Model` TEAM"** claim — it is forgeable (a single agent can mint a foreign-team signer, the #3673/PR#3677 "perfect forgery"), so a different team is **no longer** an auto-pass and now ALSO needs a receipt/attestation (reason `unattested-cross-team-claim`). Enforced consistently across `baton-independence.checkAdminIndependence`, `baton-authority/evidence-loader.deriveTrailFromGitHub` (the merge FSM), and the `consensus-receipt-check` CI validator (receipt = sha256 over provider responses in the append-only hash-chained ledger `governance/cross-family-consensus.jsonl`; panel ≥2 families distinct from the authoring family, each able to REJECT). The authorship-attestation mechanism (a committed per-team public-key registry + ed25519 verify) is fail-closed today and tracked by research child #3682. See `docs/howto/cross-family-consensus-independence.md`.
+- All governed work requires a GitHub issue and `Refs #N` in the PR body; workflow identity resolution follows `instructions/team-model-in-workflows.instructions.md`.
+- Skip baton only for: single Q&A, read-only lookup, no file edits, no state-changing tool calls.
+
+## Flaw-recognition anneal decision (required)
+
+When any active role recognizes a flaw/error during execution, it must record one explicit decision:
+- `file-ticket` — structural/repeatable gap; include `#N`
+- `log-incident-only` — one-off operational event; include `incidents.jsonl`/`pattern_id`
+- `memory-note-only` — judgment/process note with no immediate code/process delta; include memory path
+- `no-action-justified` — include a short rationale
+
+This decision must be cited in baton artifacts and summarized in `CONSULTANT_CLOSEOUT` under:
+- `mid_flight_flaws: [<flaw>, decision=<...>, artifact=<...>]`
+
+### `flaws_recognized:` block — per review-point (Epic #3425 P1-a, #3428)
+
+The discretion-dependent prose contract above is being made programmatic. Every baton artifact
+(MANAGER / COLLABORATOR / ADMIN / CONSULTANT) now carries a `flaws_recognized:` block — either a
+bare `none` or one entry per disposed candidate:
+
+```
+flaws_recognized:
+  - flaw: <short description>
+    detected_by: <F1..F8 | manual>
+    decision: file-ticket | log-incident-only | memory-note-only | no-action-justified
+    artifact: #<N> | incidents.jsonl:<pattern_id> | <memory-path> | <rationale>
+```
+
+`decision` reuses the `judgment-gate.js` `FLAW_DECISIONS` enum; `artifact` is decision-typed. The
+Consultant's `mid_flight_flaws` + `anneal_tickets_filed` remain the required closeout-aggregation
+fields; `flaws_recognized` is the per-review-point superset the other three roles gain. Validator:
+`scripts/global/megalint/flaws-recognized.js` — **ADVISORY** (warns, never blocks) until the
+replay-eval promotion gate (#3434) flips it. The field is `block` (not required) in
+`baton-artifact-schema.js` so the historical replay corpus and cross-runtime invariant are preserved.
+
+## Enforcement Points
+
+| Rule | Enforcement |
+|------|-------------|
+| Collaborator/Admin signer independence (#3532) | `baton-gates.yml` admin-gate + `baton-authority/merge` (`SIGNER_INDEPENDENT` bit) require a different `Team&Model` TEAM segment OR a verified `cross_family_receipt`; `consensus-receipt-check.yml` step re-verifies the receipt from the committed ledger. Persona-surname difference alone no longer passes. |
+| Test strategy declared per matrix | `test-evidence.yml` gate consumes `test_strategy` from `MANAGER_HANDOFF` |
+| `roles.admin` auto-emission on full baton (#2444) | `hooks/scripts/tool_activity.py` `mark_tool_activity` flips `roles["admin"] = True` when every key returned by `admin_patterns.required_admin_ops(flags, repo_type)` is set in `admin_ops`. Stop-hook `check_admin_ops` consumes the same helper. No manual state patching required. |
+
+## Baton-back review→remediation guardrail (Epic #3251 — enforced in code)
+
+When any review phase surfaces a blocking issue, the baton does not stall waiting for a
+human: it routes the issue to the remediating role and re-advances to closure
+**programmatically**. The rule lives in code (zero-token to enforce, context-loss-proof);
+this section only *describes* it (G8) — it does not carry the rule.
+
+- **Two-layer discovery, one router.** Layer A (≈40 validators + gate hooks) and Layer B
+  (a cross-model review that emits machine-readable findings) both terminate in the same
+  deterministic router. Layer B findings are parsed by
+  `scripts/global/cross-model-finding-router.js` and dispatched by
+  `scripts/global/cross-model-review-dispatch.js` (the operationalized
+  `post-merge-consultant-audit.yml` Layer-B Action); the router itself is the shipped
+  `scripts/global/baton-back.js#routeRemediation` (#3257) — no LLM, no prose.
+- **Deterministic routing rule.** Fix touches a tracked file → **Collaborator** (baton-back);
+  fix is the current role's own artifact/git-op → **current role** (block-in-place); fix is
+  issue-only governance metadata → **Manager** (hold); environmental → **override** (no
+  baton-back). Fault-owner is recorded separately from the file-editor (accountability, G8).
+- **Close-gate invariant.** A ticket cannot reach done/closed while a `## BATON_BACK` marker
+  is open on the timeline — enforced by `scripts/global/closeout-preflight.js`
+  (`batonBackGateBlocks` → `baton-back.anyOpen`), so an Epic cannot close around an open child
+  remediation. The marker also carries the finding as an actionable lesson and a bounded
+  cycle counter (default 3) that escalates to a non-blocking Tier-2 anneal.
+- **Marker persistence + disclosure labels.** `scripts/global/baton-back-set.js` posts the
+  authoritative `## BATON_BACK` timeline comment, applies the `baton-back:open` label, and a
+  metadata-only observability event is written per-ticket by
+  `scripts/global/baton-back-ledger.js` (redacted; not the consensus ledger).
+- **Graded review-coverage disclosure (G2>G3 floor).** Each review point resolves a coverage
+  rung via `scripts/global/review-coverage-resolver.js` and surfaces it as a
+  `review-coverage:{cross-family-free|cross-family-paid|same-family-paid|same-model-grounded-paid|programmatic-only}`
+  label + closeout field. `programmatic-only` (no semantic reviewer reachable) raises a client
+  UAT warning; it is the floor only under a free-only budget / no-network, never a silent skip.
+
+## MANAGER_HANDOFF schema (with test_strategy)
+
+Required fields on every `MANAGER_HANDOFF` comment:
+- `scope:` — what changes
+- `lane:` — `lane:code-change | lane:docs-research | lane:config-only | lane:no-code-remediation | lane:trivial`
+- `test_strategy:` — one of `tdd-pyramid | tdd-trophy | contract-test | golden-file | eval-harness | visual-regression | drift-lint | peer-review | manual-verify | none`
+- `acceptance:` — AC checklist
+- `gates:` — CI/governance gates that must pass
+- `anneal_tier:` (optional) — `tier-1 | tier-2 | tier-3 | null`; populate when ticket originated from a Tier-2 anneal auto-file event per Epic #1308. Default `null` / omitted for non-anneal tickets.
+
+Conditional required fields:
+- Tickets labeled `phase-gate:phase-1` MUST include `phase_gate_satisfied: yes`.
+- Tickets labeled `phase-gate:phase-1` MUST include `phase_0_sources: [#N, #N, ...]` with one or more source research-child references.
+
+`test_strategy` selected per `instructions/test-methodology-matrix.instructions.md`; missing on legacy tickets defaults to `none` (advisory). New tickets with `none` on non-permitted lane fail `test-evidence`.
+
+**Cross-family preflight requirement** (lane:code-change, Refs #2439): Before posting `COLLABORATOR_HANDOFF`, run `npm run collaborator:preflight --ticket=N`. The handoff MUST include `cross_family_rating:`, `cross_family_reviewer:`, and `cross_family_findings:` from the preflight output. The reviewer model family MUST differ from the Collaborator's `Team&Model` family.
+
+## Parent/child relationships (Sub-issues primitive)
+
+The canonical parent/child relationship uses GitHub's native **Sub-issues**
+primitive (up to 100 children per parent, 8 levels deep). The legacy prose
+`Refs Epic #N` convention remains supported for backward compatibility but
+is deprecated for new tickets. See `docs/howto/sub-issues-migration.md` for
+the migration plan and #1631 follow-on children for the helper, validator,
+and test-suite implementation.
+
+## Multi-Close PR batching (formalized #1714)
+
+A single PR MAY close multiple related tickets via multiple `Closes #N` lines, subject to all conditions below. **Historic batches before this contract landed are grandfathered**; this rule applies to PRs opened on or after 2026-05-16.
+
+### When batching is allowed
+
+All of the following must hold:
+
+- **Related ACs**: the closing tickets are children of the same parent Epic or share an `area:*` label, AND their ACs share an obvious deliverable surface (same diff, same test suite, same area).
+- **Single diff**: one branch, one diff, one PR. No squash of independent commits across siblings.
+- **Single test surface**: tests added/modified cover all closing tickets' ACs collectively (not one-test-per-ticket spread across PRs).
+- **One lead + N siblings**: the lead ticket is the lowest issue number in the batch; the branch name uses `fix/<lead-N>-...`; siblings are explicitly named in the PR body and lead ticket.
+
+### Required artifacts on the lead ticket
+
+The lead ticket receives the full 4-role baton artifact set (MANAGER_HANDOFF, COLLABORATOR_HANDOFF, ADMIN_HANDOFF, CONSULTANT_CLOSEOUT) per the standard contract.
+
+### Required artifacts on sibling tickets
+
+Each sibling ticket receives a **brief-evidence comment** with the structured fields:
+
+```
+## CONSULTANT_CLOSEOUT
+ticket: #<sibling-N> (resolved as part of batch with #<lead-N>)
+status: review
+verdict: approve_for_merge
+verification-timestamp: <ISO8601>
+
+rubric_rating: <int>/10. Full evidence on #<lead-N>.
+
+Signed-by: <human-alias>
+Team&Model: <team:model@substrate>
+Role: consultant
+```
+
+The brief evidence MUST include the 4 structured fields: `Signed-by`, `Team&Model`, `Role`, `verification-timestamp`, plus `rubric_rating`. These satisfy the `closeout-schema` signer-alias-fidelity check.
+
+### Validator recognition
+
+`scripts/global/megalint/consultant-closeout.js` recognizes the phrase "resolved as part of batch with #<N>" as a valid closeout-evidence marker (in addition to the standard substantive evidence). See `scripts/global/megalint/batch-evidence.js`.
+
+### What batching does NOT change
+
+- Each closing ticket still requires a status:done label flip at merge (auto-transitioner handles this via the `Closes #N` line).
+- Each closing ticket's labels must be advanced through the baton states (status:triage → status:ready → status:in-progress → status:testing → status:review) per the standard contract before close. Siblings can advance via the lead's MANAGER_HANDOFF; their own MANAGER_HANDOFF is NOT required.
+- Auto-escalate triggers (Epic #1736 #1743) apply per-PR regardless of batching.
+
+### Anti-pattern: when batching is NOT allowed
+
+- Tickets from different parent Epics.
+- Tickets touching different test surfaces (e.g., one is unit tests, other is integration; would force two PRs anyway).
+- Tickets where one is `lane:trivial` and another is `lane:code-change` (different validator paths).
+- Tickets where one sibling has `merge-evidence-override:approved` and another does not.
+
+## Local Override
+
+A repo may override via `.github/copilot-instructions.md`; local wins on conflict.
+
+## Cross-Team Artifact-Write Gate
+
+When a MANAGER_HANDOFF involves writing files consumed by another team's runtime,
+the `cross_runtime_writes` field is required and must include `target_team_sign_off`
+before the baton advances. See `instructions/cross-team-artifact-write.instructions.md`.
+
+## Offline contract for derive_roles_from_github (#2460, Epic #2451 Move 5)
+
+When the GitHub-derived role resolver (#2456, feature-flagged via `MEGINGJORD_DERIVE_ROLES_FROM_GH`) cannot reach GitHub:
+
+| Condition | Behavior | Operator-visible signal |
+|---|---|---|
+| First call (cold-miss): gh CLI unreachable or returns non-zero | Returns `None`; callers fall back to local-state | stderr: `[role-resolver] degraded: cold-miss for #N; falling back to local-state` |
+| Subsequent call (warm cache + gh fail) within 300s MAX_STALE | Returns last-cached value | stderr: `[role-resolver] degraded: gh-fetch-failed-using-stale for #N; falling back to stale cache` |
+| Subsequent call beyond MAX_STALE_SECONDS | Returns `None`; callers fall back to local-state | stderr: cold-miss line |
+| `gh` CLI absent (FileNotFoundError) | Same as above per cache state | same stderr lines |
+| Subprocess timeout (10s default) | Same as above per cache state | same stderr lines |
+
+**Quiet mode** for CI/cron contexts: set `MEGINGJORD_QUIET_RESOLVER=1` to suppress stderr output.
+
+**Goal-lens justification**:
+- **G6 resilience**: G6 is preserved via stale-cache fallback bounded by MAX_STALE_SECONDS=300; legacy `roles{}` continues to function when feature flag off
+- **G8 observability**: each degraded path emits a labeled stderr line so operators can diagnose; not silent
+- **G3 zero-cost in CI**: quiet-mode env flag suppresses noise without disabling the fallback path
+
+## Skill Mapping
+
+Manager: `role-manager-execution` | Collaborator: `role-collaborator-execution`
+Admin: `role-admin-execution` | Consultant: `role-consultant-critique`
+Orchestration: `role-baton-orchestrator`
+
+## Operator decision routing (#2509)
+
+When the operator (the AI agent running the baton) faces a routine yes/no dev decision (file follow-on ticket Y/N? two-ticket-or-one? accept fleet-rater verdict?), the DEFAULT routing is:
+
+1. Route to fleet decision oracle: `node scripts/global/fleet-decision-oracle.js` via `decideOnce(question, opts)`
+2. Fleet returns `{verdict: approve|reject|partial|inconclusive, rationale, model_used, escalate_to_client: bool}`
+3. If `escalate_to_client` is true (verdict inconclusive OR fleet unreachable) → THEN ask client
+4. Otherwise → operator executes per verdict; no client touch needed
+
+**Why:** per the harness's operator-identity contract (`instructions/operator-identity-context.instructions.md`), the client is design + UAT only. Asking the client to adjudicate routine dev decisions is governance-misalignment. The fleet rater (free, qwen-7b at ~30s) is the correct decision substrate.
+
+**When NOT to use fleet:**
+- Design direction (new architecture, scope expansion)
+- UAT confirmation (does the shipped behavior match user expectation)
+- Budget decisions (paid-provider lane authorization)
+- Memory has prior client preference on the specific class
+
+**Memory anchor:** `feedback_route_decisions_to_fleet_not_client` (operator-personal).

--- a/instructions/workflow-resilience.instructions.md
+++ b/instructions/workflow-resilience.instructions.md
@@ -15,6 +15,13 @@ Run `workflow-self-anneal` skill when any of these conditions is true:
 - Repeated carryover or blocked items across iterations.
 - PR review or merge latency repeatedly breaches targets.
 - Reopened issues or defects trend upward.
+- Ticket/epic local markdown state diverges from observable GitHub issue/PR evidence.
+- Any P0/P1 ticket remains `status:ready` for more than 24h without a blocker note.
+- Governance-gate bypass env var (e.g. `SKIP_CLOSEOUT_PREFLIGHT`, `PUSH_GATES_BYPASS`) used 2+ times in the same session — triggers an immediate Tier-2 anneal that promotes the underlying bug-fix to first-work in the current session. Tracked by `scripts/global/session-bypass-tracker.js`.
+- Tool-block emission (sandbox denial, hook deny, classifier deny) followed by session termination within 1 turn — Tier-2 trigger. The tool-block is redirect guidance, not a terminal state; the right adaptation is documented in operator-local memory `feedback-bash-sleep-block-recovery` (Pattern A; #2116). Surfaced after PR #2113 cycle stalled on `sleep N && cmd` sandbox block.
+- Background-task dispatch (`Bash run_in_background: true`, scheduled wake) followed by user-visible closing text without a follow-up tool call — Tier-2 trigger. Dispatch is a notification subscription, not a turn-end signal; 8 unnecessary stops in a single 2026-05-24 session followed this exact anti-pattern. See operator-local memory `feedback-bash-sleep-block-recovery` Pattern B (#2116).
+
+Ready-stall blocker note required fields: `BLOCKER_NOTE`, `owner`, `unblock_condition`, `eta_or_review_time`.
 
 ## Self-annealing constraints
 
@@ -26,9 +33,96 @@ Run `workflow-self-anneal` skill when any of these conditions is true:
 
 ## Self-annealing protocol
 
-1. Detect mismatch between expected behavior (from instructions) and observed behavior (from evidence).
+1. Detect mismatch between expected and observed behavior.
 2. Classify root cause: `ambiguity`, `missing guardrail`, `stale instruction`, `tool fragility`, or `human override`.
 3. Assess recurrence risk: `low`, `medium`, or `high`.
 4. Propose minimal docs/workflow delta that prevents recurrence.
 5. Define objective verification gate confirming the fix works.
 
+## Three-tier escalation model
+
+Anneal triggers route through one of three tiers per Epic #1308. See `[[distributed-self-anneal]]` for full design and `[[andon-pull-protocol]]` for any-role pull mechanics. The base protocol above is the Tier-2 mid-flight pivot phase.
+
+### Tier 1 — Observation (any role)
+
+Append a drift event to `~/.megingjord/incidents.jsonl` (schema v2). No threshold, no ticket. Pure trend capture for the recurrence detector.
+
+### Tier 2 — Mid-flight pivot (auto-ticket)
+
+Triggers when `severity ≥ medium` AND (recurrence ≥ 2 in 7d OR `trigger_type == manual-pull`) AND no active session-pivot AND no matching suppression entry. Effect: orchestrator pauses current baton step, snapshots state, runs the protocol above, files Manager ticket(s) to backlog, restores baton.
+
+#### Guardrail-first disposition (Epic #3380)
+
+A Tier-2 friction is, by default, an opportunity to build a **guardrail that prevents that friction for
+every team** — not a workaround note that enlarges always-resident memory and re-bills its token cost
+every session. Before a friction is recorded as a memory note, route it through the deterministic
+classifier `scripts/global/friction-classifier.js` (`classifyFriction(record)`), which maps it to one of
+four destinations:
+
+| Destination | When | Action |
+|---|---|---|
+| `guardrail-candidate` | mechanical surface named (gate / hook / validator / regex / state-file / parser / enforcer) AND recurrence ≥ 2 AND severity ≥ medium AND reproducible | file a guardrail ticket; build a **hook → validator → test → CI backstop** (prevention-first ladder) |
+| `skill` | a correct, reusable multi-step procedure (≥ 3 ordered steps), not a defect | promote to a skill / runbook |
+| `semantic-memory` | judgment / preference / client directive / external fact | keep a memory note — this is memory's *correct* use |
+| `forget` | one-off below the recurrence floor | let it decay in `incidents.jsonl`; do not promote to memory |
+
+**Anti-over-route (binding):** judgment/preference **wins on collision** — a record that names a mechanical
+surface *and* hits the judgment lexicon (or `trigger_role: client`) routes to `semantic-memory`, never to a
+guardrail. Unknown/low-confidence inputs **fail open** to `semantic-memory`. A preference is never
+auto-converted into a blocking guardrail.
+
+**Consolidation / forgetting policy:** on the 2nd in-window recurrence of a `guardrail-candidate` pattern,
+file (or de-dupe onto) a guardrail ticket and link the note to it. When that guardrail ships
+(`resolution:released`), **delete the originating note(s) and its MEMORY.md index line** — the guardrail now
+prevents the recurrence, so the note's job is done. `forget`-class records decay under `log-rotation.js`;
+they are never promoted to MEMORY.md.
+
+**Cross-team & promotion:** the classifier + lexicon live in `scripts/global/` and `config/` (the shared,
+runtime-agnostic surface mirrored to claude-code / copilot / codex / antigravity) — one guardrail protects
+all four teams. Promotion of the memory-write guard from advisory to blocking is gated on replay-eval
+precision ≥ 0.85 against `tests/fixtures/friction-corpus.json` (`friction-classifier-replay-eval.js`),
+**never a calendar threshold**. Operator guide: `docs/howto/guardrail-first-anneal.md`.
+
+### Tier 3 — Consultant goal-failure escalation
+
+Authority: Consultant only. Triggered when consultant rubric finds G1–G9 goal violation post-implementation. Effect: invoke Manager to (a) reopen failed AC/ticket via baton, (b) file new self-anneal Epic for systemic patterns.
+
+### Authority matrix
+
+| Action | Authority |
+|---|---|
+| Append Tier-1 event | Any role |
+| Request Tier-2 pivot | Any role (router classifies) |
+| Invoke Tier-3 escalation | Consultant only |
+| File Manager ticket from anneal | Manager (auto-routed via Tier-2 workflow) |
+
+### Bounded-loop guards (kill switches)
+
+- Max 1 active pivot per session (single-flight)
+- Max 3 pivots per 24h per session (rate-limit)
+- Max 5 anneal tickets per 7-day window per `pattern_id` (suppression cooperation with #1220)
+- Anneal step counter aborts with `decision: defer` if >50 tool calls
+- All trips emit `event:kill-switch-trip` for dashboard observability
+
+## Breaking-Change Recovery Handoff
+
+When Tier-3 Consultant escalation identifies a G1–G9 goal violation caused by a
+merged breaking change, invoke the **Breaking-Change Recovery Protocol** from
+`instructions/breaking-change-recovery.instructions.md`. The protocol covers
+six phases: Detect → Revert → Triage → Fix → Re-merge with smoke evidence →
+Casualty re-author. Tier-3 authority (Consultant) initiates; Manager and Admin
+execute the revert and fix phases.
+
+## Documentation drift detection
+
+Run `docs-drift-maintenance` skill after any change to:
+- Commands, CLI flags, or API behavior.
+- Configuration files, defaults, or environment variables.
+- Workflows, CI/CD pipelines, or automation scripts.
+- UX-visible behavior, user-facing features, or settings.
+
+## catch-empty suppression contract
+
+- `scripts/global/catch-empty-lint.sh` intentionally scans `.github/workflows/` only.
+- `scripts/global/` and `hooks/scripts/` may contain intentional non-empty catch handlers and are governed by code review plus unit tests instead of the workflow YAML lint.
+- Use `// catch-empty: <reason>` only for best-effort label/comment cleanup or equivalent known-safe GitHub API misses; if the handler can distinguish expected failures, prefer filtering the expected status code and rethrowing everything else.

--- a/skills/docs-drift-maintenance/SKILL.md
+++ b/skills/docs-drift-maintenance/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: docs-drift-maintenance
 description: Detect and remediate documentation drift after code, config, workflow, or UX changes. Use after implementation, before merge, and before release.
+argument-hint: ""
+user-invocable: true
+disable-model-invocation: false
 ---
 
 # Docs Drift Maintenance
@@ -9,14 +12,43 @@ description: Detect and remediate documentation drift after code, config, workfl
 
 - After any change to commands, config, workflows, API/CLI behavior, or release process.
 - Before merge/release if docs accuracy is part of acceptance.
+- Before declaring a feature complete (not just gates-complete).
+
+## Documentation coverage matrix (required)
+
+For feature-adds and behavior changes, evaluate all applicable surfaces:
+
+1. Local operator docs
+   - `README.md`
+   - `docs/technical/system-stability.md`
+   - `docs/workflow/learnings.md`
+2. Public repository docs
+   - `.github/CONTRIBUTING.md`
+   - `.github/PULL_REQUEST_TEMPLATE.md`
+   - community profile files (`CODE_OF_CONDUCT.md`, `SECURITY.md`, `SUPPORT.md`) when behavior changes affect contributor workflow
+3. VS Code extension public profile
+   - `vscode-extension/README.md`
+   - `vscode-extension/CHANGELOG.md`
+   - `vscode-extension/package.json` metadata/settings descriptions
+4. Release traceability docs
+   - root `CHANGELOG.md`
+   - release notes / GitHub release object
+5. Inline code documentation (added #101 — global linting governance)
+   - **JS/TS**: JSDoc on all exported/public functions (`@param`, `@returns`, `@description`)
+   - **Python**: Google-style docstrings on all public functions, classes, and modules
+   - **Bash**: Header comment block on each script; inline comments on non-obvious logic
+   - **CSS**: Section header comments; non-obvious rule explanations
+   - Governed by `lint-configs/eslint.config.devenv.js` (JSDoc rules) and `lint-configs/ruff.devenv.toml` (D rules)
+   - Drift check: run `npm run lint:all`; any new `jsdoc/*` or `D*` violations are inline-doc drift
 
 ## Procedure
 
-1. Enumerate changed behavior/config/workflow surfaces.
-2. Map each change to impacted docs (`README`, `CHANGELOG`, operational docs, runbooks).
+1. Enumerate changed behavior/config/workflow/code surfaces.
+2. Map each change to impacted docs using the coverage matrix above.
 3. Identify stale, missing, or contradictory statements.
 4. Apply minimal doc deltas that restore correctness and traceability.
-5. Verify that docs now match actual behavior and invocation paths.
+5. Verify docs now match actual behavior and invocation paths.
+6. Record what was intentionally N/A and why.
 
 ## Output format
 
@@ -25,9 +57,11 @@ description: Detect and remediate documentation drift after code, config, workfl
 - `required_updates`: concrete edits required
 - `verification_checks`: objective checks confirming alignment
 - `evidence`: code/workflow changes correlated to docs updates
+- `not_applicable`: surfaces reviewed but intentionally N/A
 
 ## Standards
 
 - Docs updates must ship with behavior/config/workflow changes.
 - Keep wording precise, testable, and user-actionable.
 - Avoid speculative claims unsupported by current implementation.
+- "All tests pass" does not imply docs are complete.

--- a/skills/github-actions-security-hardening/SKILL.md
+++ b/skills/github-actions-security-hardening/SKILL.md
@@ -60,3 +60,14 @@ missing_evidence:
 ## Invocation policy
 
 Run in pre-merge for workflow/security-sensitive changes and in periodic governance audits.
+
+## Repo workflow inventory
+
+| Workflow | Trigger | Permissions | Status |
+|---|---|---|---|
+| `.github/workflows/lint.yml` | PR/push to main | default read | ✅ active |
+| `.github/workflows/label-lint.yml` | issues events | `issues:write`, `contents:read` | ✅ active (ADR-010) |
+
+`label-lint.yml` enforces ADR-010 rules 1–4 on every issue event. Any violation
+posts an explanatory comment and fails the check. See
+`research/adr/010-ticket-status-role-model.md`.

--- a/skills/github-ops-excellence/SKILL.md
+++ b/skills/github-ops-excellence/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: github-ops-excellence
-description: Define and apply expert GitHub policy profiles and control catalogs used by specialized execution skills across ticketing, review/merge, governance, and release flows.
-argument-hint: [mode: triage|refinement|pre-pr|pre-merge|sprint-health|release-readiness|incident-flow|admin-audit] [scope: repo|team|org|enterprise] [policy-profile: strict|standard|light]
+description: "Define and apply expert GitHub policy profiles and control catalogs used by specialized execution skills across ticketing, review/merge, governance, and release flows."
+argument-hint: "[mode: triage|refinement|pre-pr|pre-merge|sprint-health|release-readiness|incident-flow|admin-audit] [scope: repo|team|org|enterprise] [policy-profile: strict|standard|light]"
 user-invocable: true
 disable-model-invocation: false
 ---

--- a/skills/github-ops-tree-router/SKILL.md
+++ b/skills/github-ops-tree-router/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: github-ops-tree-router
-description: Route GitHub workflow requests through a capability-first GitHub skill tree with explicit ownership boundaries and minimal overlap.
-argument-hint: [goal: ticket-lifecycle|agile-projects|review-merge|release-incident|repo-governance|actions-security|ruleset-architecture|process-hardening] [policy-profile: strict|standard|light]
+description: "Route GitHub workflow requests through a capability-first GitHub skill tree with explicit ownership boundaries and minimal overlap."
+argument-hint: "[goal: ticket-lifecycle|agile-projects|review-merge|release-incident|repo-governance|actions-security|ruleset-architecture|process-hardening] [policy-profile: strict|standard|light]"
 user-invocable: true
 disable-model-invocation: false
 ---

--- a/skills/github-projects-agile-linkage/SKILL.md
+++ b/skills/github-projects-agile-linkage/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: github-projects-agile-linkage
-description: Apply Agile linkage controls in GitHub using issue types, sub-issues, dependencies, issue-branch/PR linkage, project fields, and built-in automations.
-argument-hint: [mode: audit|plan|apply|verify] [scope: repo|org] [policy-profile: strict|standard|light]
+description: "Apply Agile linkage controls in GitHub using issue types, sub-issues, dependencies, issue-branch/PR linkage, project fields, and built-in automations."
+argument-hint: "[mode: audit|plan|apply|verify] [scope: repo|org] [policy-profile: strict|standard|light]"
 user-invocable: true
 disable-model-invocation: false
 ---

--- a/skills/github-release-incident-flow/SKILL.md
+++ b/skills/github-release-incident-flow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: github-release-incident-flow
-description: Govern release readiness and incident response flow in GitHub with rollback evidence, hotfix linkage, and follow-up controls.
-argument-hint: [mode: release-readiness|incident-flow|post-incident] [scope: repo|org] [policy-profile: strict|standard|light]
+description: "Govern release readiness and incident response flow in GitHub with rollback evidence, hotfix linkage, and follow-up controls."
+argument-hint: "[mode: release-readiness|incident-flow|post-incident] [scope: repo|org] [policy-profile: strict|standard|light]"
 user-invocable: true
 disable-model-invocation: false
 ---

--- a/skills/github-review-merge-admin/SKILL.md
+++ b/skills/github-review-merge-admin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: github-review-merge-admin
-description: Enforce review and merge administration gates with required checks, approvals, conversation resolution, rulesets, and merge queue readiness.
-argument-hint: [mode: pre-review|pre-merge|admin-audit] [scope: repo|org] [policy-profile: strict|standard|light]
+description: "Enforce review and merge administration gates with required checks, approvals, conversation resolution, rulesets, and merge queue readiness."
+argument-hint: "[mode: pre-review|pre-merge|admin-audit] [scope: repo|org] [policy-profile: strict|standard|light]"
 user-invocable: true
 disable-model-invocation: false
 ---

--- a/skills/github-ticket-lifecycle-orchestrator/SKILL.md
+++ b/skills/github-ticket-lifecycle-orchestrator/SKILL.md
@@ -1,180 +1,78 @@
 ---
 name: github-ticket-lifecycle-orchestrator
-description: Orchestrate end-to-end ticket lifecycle across manager, collaborator, reviewer, and admin roles in GitHub: create/refine, assign, branch, develop, PR, review, merge, and closeout with evidence.
-argument-hint: [phase: intake|planning|assignment|execution|pre-pr|review|pre-merge|closeout] [scope: repo|org] [policy-profile: strict|standard|light]
+description: Naming conventions and phase protocol for GitHub ticket lifecycle. Baton workflow in manager-ticket-lifecycle.
+argument-hint: [phase: intake|planning|execution|pre-pr|review|merge|closeout]
 user-invocable: true
 disable-model-invocation: false
 ---
 
 # GitHub Ticket Lifecycle Orchestrator
 
-## Purpose
-
-Provide one bounded operating flow that connects issue management, branching, development execution, review, and merge administration.
-
 ## Hard constraints
 
-1. No unbounded loops.
-2. Max one lifecycle pass per invocation.
-3. If required evidence is missing, return `NO_CHANGE` with missing artifacts.
-4. Do not claim merge/closeout success without verification evidence.
+1. No unbounded loops. Max one lifecycle pass per invocation.
+2. If required evidence is missing, return `NO_CHANGE` with missing artifacts.
+3. Do not claim merge/closeout success without verification evidence.
 
-## Issue ID and title standard (universal — all repos)
+## Issue title format — plain imperative
 
-This standard applies to every repository managed under this skill set. Agents
-must apply it at intake for every new issue and enforce it during triage audits.
+`<Imperative verb phrase describing the desired outcome>` [≤ 72 chars]
 
-### Canonical ticket identifier
+- Start with imperative verb: "Fix", "Add", "Normalize", "Audit", "Stabilize"
+- Plain English, human-scannable in boards and notifications
+- **No `type(scope):` prefix** — type/scope expressed via labels
+- No bracket tags `[BUG]`, no parallel IDs `TICKET-NNN`
 
-- The GitHub issue number (`#N`) is the **sole canonical ticket identifier**.
-- Do **not** create or maintain parallel local ID schemes (`TICKET-NNN`, `JIRA-123`,
-  audit-doc sequential IDs, etc.). These diverge from `#N` and break closing keywords,
-  branch linkage, and cross-repo references.
-- When migrating tickets from external sources (audit docs, Notion, spreadsheets),
-  use the assigned `#N` immediately after creation; discard the source ID or note
-  it as an alias only.
+Good: `Fix header nav contrast on dark hero backgrounds`
+Bad: ~~`fix(nav): fix header nav contrast`~~ ~~`TICKET-008: Fix header`~~
 
-### Issue title format — plain imperative (human-scannable)
+## Commit and PR title format — Conventional Commits
 
-Issue titles must be readable in a project board, search result, or notification
-without any parsing. **Do not apply Conventional Commits prefixes to issue titles.**
-Type and scope are expressed via labels, not the title.
+`<type>(<scope>): <imperative description>` [≤ 72 chars]
 
-```
-<Imperative verb phrase describing the desired outcome>  [≤ 72 chars]
-```
+Types: `feat` `fix` `chore` `content` `perf` `refactor` `docs` `style` `test`
 
-| Rule                           | Detail                                                            |
-| ------------------------------ | ----------------------------------------------------------------- |
-| Start with an imperative verb  | "Fix", "Add", "Normalize", "Redesign", "Audit", "Stabilize"       |
-| Plain English, human-scannable | Must make sense standalone in a board or search result            |
-| No `type(scope):` prefix       | Type is a label (`type: bug-fix`); scope is a label (`area: seo`) |
-| ≤ 72 chars                     | Fits project board columns and notification subjects              |
+## Branch naming
 
-**Correct examples:**
+`<type>/<issue-number>-<short-slug>` — e.g. `fix/5-nav-contrast`, `feat/11-footer-redesign`
 
-- `Fix header nav contrast on dark hero backgrounds`
-- `Normalize /services-store title and meta description for Austin SEO`
-- `Redesign footer layout, hierarchy, and mobile composition`
-- `Audit interactive states and produce sitewide affordance spec`
-- `Stabilize Playwright QA runtime for repeatable pre-publish checks`
+## Template requirements
 
-**Incorrect — do not use:**
+Every repo must have `.github/ISSUE_TEMPLATE/` with at minimum: bug, task, epic forms.
+Config: `blank_issues_enabled: false`. Plus `PULL_REQUEST_TEMPLATE.md` with issue linkage.
 
-- ~~`fix(nav-contrast): fix header nav contrast`~~ — Conventional Commits belongs on commits/PRs, not issues; also redundant
-- ~~`TICKET-008: Fix header nav contrast`~~ — parallel ID scheme
-- ~~`[BUG] header nav contrast issue`~~ — bracket tags are label substitutes
+## Phase protocol (compact)
 
-### Commit and PR title format — Conventional Commits
+| Phase | Key actions |
+|---|---|
+| **intake** | Validate issue, apply labels/priority/milestone |
+| **planning** | Split to sub-issues, add dependencies, set project fields |
+| **execution** | One branch per ticket, link in Development panel, atomic commits |
+| **pre-pr** | PR links issue with closing keywords, test evidence attached |
+| **review** | Resolve feedback, re-run checks after changes |
+| **merge** | Required reviews/checks satisfied, merge per repo policy |
+| **closeout** | Issue state transition, branch deletion, post-merge cleanup |
 
-The `type(scope): description` format (Conventional Commits) belongs on **commit
-messages and PR titles** — not issue titles.
+## Label taxonomy reference
 
-```
-<type>(<scope>): <imperative description>  [≤ 72 chars]
-```
+See `manager-ticket-lifecycle` for full label taxonomy:
+`type:*`, `status:*`, `priority:*`, `area:*`, `role:*`
 
-Allowed types: `feat` `fix` `chore` `content` `perf` `refactor` `docs` `style` `test`
-
-Examples:
-
-- `fix(nav-contrast): apply WCAG AA contrast to header nav links`
-- `feat(footer): redesign footer layout and mobile composition`
-- `chore(qa-runtime): document mem-watchdog pause sequence in uat-guide`
-
-### Branch naming
-
-```
-<type>/<issue-number>-<short-slug>
-```
-
-Examples: `fix/5-nav-contrast`, `feat/11-footer-redesign`, `chore/13-qa-runtime`
-
-The `<issue-number>` segment creates an unambiguous link to the GitHub issue
-without relying on closing keywords alone.
-
-### Template requirements
-
-Every repository must have:
-
-- `.github/ISSUE_TEMPLATE/` containing **at minimum** one bug form, one task form, and one epic form (filenames may vary, e.g. `bug-report.yml`, `task-request.yml`)
-- `blank_issues_enabled: false` in `.github/ISSUE_TEMPLATE/config.yml`
-- A `PULL_REQUEST_TEMPLATE.md` with linked issue, validation evidence, and risk fields
-
-Recommended: include a research/audit issue form when `type: research` is used in the repository workflow.
-
-The triage phase must verify template adherence before any issue enters planning.
-
----
-
-## Phase protocol
-
-### `intake`
-
-- Validate issue statement, acceptance criteria, and business impact.
-- Apply labels, type, priority, and milestone/iteration.
-
-### `planning`
-
-- Split large work into sub-issues.
-- Add dependencies (`blocked by` / `blocking`).
-- Ensure project item fields are set (status, priority, iteration, owner).
-
-### `assignment`
-
-- Confirm single responsible owner.
-- Confirm due window/iteration and unblocker owner for blockers.
-
-### `execution`
-
-- One branch per ticket concern.
-- Link branch in issue Development panel.
-- Keep commits atomic and scoped.
-
-### `pre-pr`
-
-- PR links issue(s) with closing keywords where appropriate.
-- Test/validation evidence attached.
-- Reviewer(s) and CODEOWNERS requested.
-
-### `review`
-
-- Resolve feedback; keep conversation state clean.
-- Re-run required checks after substantive changes.
-
-### `pre-merge`
-
-- Required reviews/checks/rulesets all satisfied.
-- Merge method follows repo policy.
-
-### `closeout`
-
-- Confirm issue state transition and project status updates.
-- Confirm branch deletion and post-merge cleanup.
-
-## Output format (required)
+## Output format
 
 ```text
 TICKET_LIFECYCLE_REPORT
-phase: <intake|planning|assignment|execution|pre-pr|review|pre-merge|closeout>
+phase: <phase>
 scope: <repo|org>
 policy_profile: <strict|standard|light>
-
 checks:
 - id: C1
   result: <pass|fail|partial>
-  observation: <what was found>
-  expected: <required state>
-
+  observation: <finding>
 actions:
 1) priority: <P1|P2|P3>
-   owner: <role/person>
-   change: <specific action>
-   verification: <objective pass condition>
-
-decision:
-- <apply|defer|NO_CHANGE>
-
-missing_evidence:
-- <none or required artifacts>
+   owner: <role>
+   change: <action>
+decision: <apply|defer|NO_CHANGE>
+missing_evidence: <none or list>
 ```

--- a/skills/mem-watchdog-ops/SKILL.md
+++ b/skills/mem-watchdog-ops/SKILL.md
@@ -79,8 +79,8 @@ The daemon detects active Playwright sessions via `pgrep -f 'node.*playwright'`.
 
 ## Key Repo References
 
-- [Daemon logic](../../mem-watchdog.sh)
-- [Extension activation](../../extension.js)
-- [Dashboard/actions](../../commands.js)
-- [Config bridge](../../configWriter.js)
-- [System stability doc](../../../../docs/technical/system-stability.md)
+- [Snapshot helper](watchdog-snapshot.sh) — the in-repo memory snapshot script shipped with this skill.
+
+The watchdog daemon, extension activation, dashboard actions, config bridge, and the
+system-stability design doc live in the upstream VS Code extension repository (the
+canonical home of this skill), not in this harness checkout.

--- a/skills/operator-identity-context/SKILL.md
+++ b/skills/operator-identity-context/SKILL.md
@@ -10,97 +10,78 @@ disable-model-invocation: false
 
 ## Purpose
 
-Establish and enforce the operator authority model for every session. This skill encodes who does what, what access level the agent has, and the core automation mandate. It must be loaded at the start of every task and re-applied whenever the agent is tempted to ask the user to "manually" do something.
-
-This skill is **global** (user-level) and applies across all repositories on this machine.
-
----
+Establish and enforce the operator authority model for every session. This skill encodes who does what, what access level the agent has, and the core automation mandate.
 
 ## Identity Model
 
-| Role             | Party  | Responsibilities                                                               |
-| ---------------- | ------ | ------------------------------------------------------------------------------ |
-| **Manager**      | Agent  | Frames scope, constraints, plan, gates, and acceptance criteria                |
-| **Collaborator** | Agent  | Implements code/config/docs and executes local validation                       |
-| **Admin**        | Agent  | Executes operational tasks (services, runtime controls, git/release operations) |
-| **Consultant**   | Agent  | Performs independent critique, risk analysis, and post-change recommendations   |
-| **Client**       | User   | Approves design direction; performs UAT visual confirmation when requested      |
+| Role             | Party  | Responsibilities                                          |
+| ---------------- | ------ | --------------------------------------------------------- |
+| **Manager**      | Agent  | Frames scope, constraints, plan, gates, acceptance criteria |
+| **Collaborator** | Agent  | Implements code/config/docs and executes local validation |
+| **Admin**        | Agent  | Executes operational tasks (services, runtime, git/release) |
+| **Consultant**   | Agent  | Independent critique, risk analysis, recommendations      |
+| **Client**       | User   | Approves design direction; UAT visual confirmation        |
 
 **Execution mode: single-thread baton handoff.**
-Only one role is active at a time. A role may proceed only after emitting handoff evidence for the next role.
+Only one role active at a time. Role proceeds only after emitting handoff evidence.
 
-**The user is never asked to type a command, paste content, edit a file, or click a button in any external system** unless physically unavoidable (e.g., hardware 2FA).
-
----
+**The user is never asked to type a command, paste content, edit a file, or click a button** unless physically unavoidable (e.g., hardware 2FA).
 
 ## Authority Inventory (baseline)
 
-### Machine
+### Machines (multi-platform mesh)
 
+Fleet topology is auto-detected via `fleet-config.js`. See `network-platform-resources` for full inventory.
+
+**Primary (local)**
 - OS: Linux (Chromebook / Crostini container)
-- User: `curtisfranks`
 - Root access: Full (`sudo` no-password)
-- RAM: ~6.3 GB usable (mem-watchdog active — always stop before browser automation)
 - Node.js, Playwright, `gh` CLI, `git` all installed and authenticated
 
-### Git and hosting
+**Remote fleet** — resolved at runtime via Tailscale auto-detection.
+Load `network-platform-resources` for connection methods and offloading rules.
 
-- Agent handles repository operations end-to-end (branching, commits, PR lifecycle, merge/admin tasks) subject to repo policy.
-- Platform capabilities must be verified before recommending governance actions.
+### Git and hosting
+- Agent handles repository operations end-to-end subject to repo policy.
+- Platform capabilities verified before recommending governance actions.
 
 ### Repository specificity
-
 - Global skill is baseline only.
-- Repository-local instructions and skills define repo-specific constraints and must be applied as overlays.
-
----
+- Repository-local instructions define repo-specific constraints as overlays.
 
 ## Automation Mandate
 
 ### Hard rules
 
-1. **Never say "you will need to manually…"** — if automation doesn't exist, build it.
-2. **Never say "please paste this into…"** — if content must go somewhere, script the delivery.
-3. **Never say "you'll need to log in to…"** — use saved session cookies; if expired, re-authenticate headlessly where possible; headed if required (agent runs it, not user).
-4. **Never defer a step with "this requires manual access to…"** — research tools, APIs, Playwright flows, or workarounds first.
-5. If after exhausting research a step genuinely cannot be automated (e.g. a CAPTCHA, a physical 2FA device in the user's possession, or a policy that blocks programmatic access), state that explicitly with evidence, and minimize what the user must do to the absolute smallest action.
+1. **Never say "you will need to manually…"** — build automation if missing.
+2. **Never say "please paste this into…"** — script the delivery.
+3. **Never say "you'll need to log in to…"** — use saved sessions or headless auth.
+4. **Never defer with "this requires manual access to…"** — research APIs/Playwright first.
+5. If genuinely not automatable, state evidence and minimize user action.
 
 ### Research protocol (when automation gap is found)
 
 1. Check existing scripts in `scripts/` for established patterns.
 2. Check `scripts/scratch/` for prior exploration data.
-3. Inspect the target system's admin UI DOM via Playwright probe script.
+3. Inspect target system's admin UI DOM via Playwright probe.
 4. Search for REST/GraphQL APIs offered by the target system.
-5. If API access is blocked, fall back to Playwright UI automation.
-6. Document findings in the repository's technical docs before implementing.
-
----
+5. If API blocked, fall back to Playwright UI automation.
+6. Document findings before implementing.
 
 ## Session Start Checklist
 
-When starting any task in this workspace:
-
 - [ ] Confirm `git status` is clean or understand current WIP state
-- [ ] Confirm active branch per repository policy (never bypass protected branch rules)
+- [ ] Confirm active branch per repository policy
 - [ ] Review open issues for ticket context
+- [ ] Run `role-baton-orchestrator` — emit `MANAGER_HANDOFF` before implementation
 - [ ] Run `repo-standards-router` for standards/gate routing
-- [ ] If this is a post-failure or process drift situation: run `workflow-self-anneal`
-- [ ] For multi-step implementation: run `role-baton-orchestrator`
+- [ ] If post-failure or drift: run `workflow-self-anneal`
 - [ ] Never ask user to do anything before attempting all automation options
-
----
 
 ## Self-Audit Triggers
 
-Run this skill's audit mode (`workflow-self-anneal`) when:
-
+Run audit mode when:
 - You find yourself writing "you'll need to…" or "please manually…"
 - A gap in automation causes a task to stall
 - After a VS Code crash or OOM event
-- At the start of a new session after a context summarization
-
----
-
-## Why This Skill Exists
-
-This skill was created because earlier sessions repeatedly asked the user to paste code into Squarespace manually, when the agent had full Playwright admin access and the existing publish script already demonstrated the automation pattern. The root cause was no persistent, always-loaded instruction encoding the operator authority model and automation mandate. This skill closes that gap permanently.
+- At the start of a new session after context summarization

--- a/skills/playwright-vision-low-resource/SKILL.md
+++ b/skills/playwright-vision-low-resource/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: playwright-vision-low-resource
-description: Apply a low-resource operating profile for Playwright MCP + Claude Vision on constrained machines. Use this at session start, before visual QA, or after browser-context/OOM failures. Establishes bounded retries, local-vs-remote execution split, and optimized screenshot/vision practices.
-argument-hint: [mode: local-smoke|local-debug|remote-full] [scope: mcp|playwright|vision|all]
+description: "Apply a low-resource operating profile for Playwright MCP + Claude Vision on constrained machines. Use this at session start, before visual QA, or after browser-context/OOM failures. Establishes bounded retries, local-vs-remote execution split, and optimized screenshot/vision practices."
+argument-hint: "[mode: local-smoke|local-debug|remote-full] [scope: mcp|playwright|vision|all]"
 user-invocable: true
 disable-model-invocation: false
 ---

--- a/skills/release-version-integrity/SKILL.md
+++ b/skills/release-version-integrity/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: release-version-integrity
 description: Validate and enforce release version integrity across tags, manifests, changelogs, and publish workflows. Use before tagging, publishing, or when release metadata drift is suspected.
+argument-hint: ""
+user-invocable: true
+disable-model-invocation: false
 ---
 
 # Release Version Integrity

--- a/skills/repo-onboarding-standards/SKILL.md
+++ b/skills/repo-onboarding-standards/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: repo-onboarding-standards
 description: Onboard any repository into a standardized Copilot + CI governance baseline. Use for new repos and first-time sessions to ensure immediate standards adoption.
+argument-hint: ""
+user-invocable: true
+disable-model-invocation: false
 ---
 
 # Repo Onboarding Standards
@@ -9,23 +12,27 @@ description: Onboard any repository into a standardized Copilot + CI governance 
 
 - First session in a new repository.
 - Existing repositories lacking standardized AI customization and release/security gates.
+- Requests like: "include all global-skills in your initialization process."
 
 ## Procedure
 
-1. Classify repository type and risk profile using existing routing skills.
-2. Generate baseline repo instructions (`.github/copilot-instructions.md`) with build/test/gate truth.
-3. Add targeted `.github/instructions/*.instructions.md` files for stack-specific rules.
-4. Verify CI has minimum baseline: lint/test, dependency/security review, artifact/release checks.
-5. Add or update release policy controls (version integrity, docs sync, packaging audit).
-6. For platforms that support exact-version install/pin, require version-selectability controls:
+1. Run `global-skills-bootstrap` in `mode=init` for repository scaffolding.
+2. **Provision canonical label taxonomy**: `node scripts/global/label-provision.js --repo=<owner/repo>`. This seeds all `type:*`, `status:*`, `priority:*`, `role:*`, `area:*`, `lane:*`, `resolution:*`, and governance labels required for the baton lifecycle. Manifest: `scripts/global/label-manifest.json` (Refs #2785).
+3. Classify repository type and risk profile using existing routing skills.
+3. Generate baseline repo instructions (`.github/copilot-instructions.md`) with build/test/gate truth.
+4. Add targeted `.github/instructions/*.instructions.md` files for stack-specific rules.
+5. Verify CI has minimum baseline: lint/test, dependency/security review, artifact/release checks.
+6. Add or update release policy controls (version integrity, docs sync, packaging audit).
+7. For platforms that support exact-version install/pin, require version-selectability controls:
 	- immutable artifact retention,
 	- exact-version install smoke checks,
 	- canonical version index/source alignment for update prompts,
 	- documented rollback and version-yank policy.
-7. Produce an onboarding report with required vs optional controls and evidence.
+8. Produce an onboarding report with required vs optional controls and evidence.
 
 ## Required handoffs
 
+- Run `global-skills-bootstrap` first for new repositories.
 - Route standards selection via `repo-standards-router`.
 - Route GitHub workflow governance controls via `github-ops-tree-router`.
 - Use `workflow-self-anneal` only post-failure/process mismatch.

--- a/skills/repo-profile-governance/SKILL.md
+++ b/skills/repo-profile-governance/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: repo-profile-governance
-description: Audit and harden repository profile, community health, discoverability metadata, and contribution surfaces across repos using bounded, evidence-based checks.
-argument-hint: [mode: profile-audit|profile-remediate|profile-weekly-check] [scope: repo|org] [visibility: public|private] [policy-profile: strict|standard|light]
+description: "Audit and harden repository profile, community health, discoverability metadata, and contribution surfaces across repos using bounded, evidence-based checks."
+argument-hint: "[mode: profile-audit|profile-remediate|profile-weekly-check] [scope: repo|org] [visibility: public|private] [policy-profile: strict|standard|light]"
 user-invocable: true
 disable-model-invocation: false
 ---

--- a/skills/repo-standards-router/SKILL.md
+++ b/skills/repo-standards-router/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: repo-standards-router
-description: Classify a repository by app type and route it to the correct standards branch, policy profile, and verification gates.
-argument-hint: [primary-type: website-static|web-app|library-sdk|infra-automation|auto-detect] [policy-profile: strict|standard|light] [overlays: security|collaboration|release|observability]
+description: "Classify a repository by app type and route it to the correct standards branch, policy profile, and verification gates."
+argument-hint: "[primary-type: website-static|web-app|library-sdk|infra-automation|auto-detect] [policy-profile: strict|standard|light] [overlays: security|collaboration|release|observability]"
 user-invocable: true
 disable-model-invocation: false
 ---
@@ -35,7 +35,7 @@ If the request includes GitHub workflow governance controls, hand off to `github
 1. Detect `primary_type` from runtime intent and repository artifacts.
 2. Detect `secondary_types` only when overlap is clear and evidence-backed.
 3. Apply `core-baseline` controls.
-4. Apply primary-type controls from [APP-TYPE-SKILL-TREE.md](../APP-TYPE-SKILL-TREE.md).
+4. Apply primary-type controls per the app-type classification (the `core-baseline` controls above plus the per-type overlays selected in steps 5-6).
 5. Apply selected overlays (`security`, `collaboration`, `release`, optional `observability`).
 6. Calibrate severity with `policy_profile`.
 7. Emit actionable controls and checks.
@@ -81,7 +81,7 @@ missing_controls:
 - <none or control gaps not yet covered by current branches>
 
 skills_to_run_next:
-- <none|repo-profile-governance|github-ops-tree-router|workflow-self-anneal>
+- <none|web-regression-governance|repo-profile-governance|github-ops-tree-router|workflow-self-anneal>
 
 decision:
 - <apply|defer|NO_CHANGE>
@@ -95,8 +95,8 @@ evolution_todos:
 
 ## App-type branch controls (summary)
 
-- `website-static`: SEO/schema sync, visual regression, responsive QA, WCAG AA baseline, performance budgets.
-- `web-app`: component/e2e testing, auth/session hardening, dependency controls, WCAG AA.
+- `website-static`: SEO/schema sync, visual regression, responsive QA, WCAG AA baseline, performance budgets; run `web-regression-governance` when runtime injection/DOM mutation risks exist.
+- `web-app`: component/e2e testing, auth/session hardening, dependency controls, WCAG AA; run `web-regression-governance` for route-level visual/DOM/runtime invariant enforcement.
 - `library-sdk`: compatibility policy, SemVer, changelog quality, consumer examples.
 - `infra-automation`: least privilege, pinned dependencies/actions, policy checks, runbooks.
 
@@ -127,3 +127,10 @@ Recommend adding a new branch only if all are true:
 1. Repeated need appears in at least 2 repositories.
 2. At least 3 controls are not covered by existing primary types + overlays.
 3. Risk is meaningful if left as ad-hoc guidance.
+
+## Cross-Team Artifact-Write Flag
+
+When routing a repo that authors config files consumed by another team's runtime
+(e.g., Codex team writing `.claude/settings.json`), flag the ticket for the
+cross-team artifact-write contract. See
+`instructions/cross-team-artifact-write.instructions.md`.

--- a/skills/role-admin-execution/SKILL.md
+++ b/skills/role-admin-execution/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: role-admin-execution
-description: Execute operational tasks after validated implementation: runtime controls, git/PR/release flow, and governance checks.
-argument-hint: [ops-scope: runtime|git-pr|release|mixed]
+description: "Execute operational tasks after validated implementation: runtime controls, git/PR/release flow, and governance checks."
+argument-hint: "[ops-scope: runtime|git-pr|release|mixed]"
 user-invocable: true
 disable-model-invocation: false
 ---
@@ -14,6 +14,44 @@ disable-model-invocation: false
 - Perform git/PR/release administration consistent with policy.
 - Execute required post-merge/post-deploy governance checklist items.
 
+## Upstream verification (from Collaborator)
+
+Before merging/deploying, verify:
+- Validation evidence exists for EVERY gate in Manager's scope.
+- Scope compliance: implementation matches Manager's criteria list.
+- No un-flagged scope drift from Collaborator.
+- Admin checks process, NOT solution quality (that's Consultant).
+
+## Ticket baton protocol
+
+1. Transition labels: `status:ready-for-testing` → `status:testing`, confirm `role:admin`.
+2. After merge: transition `status:testing` → `status:passed-testing`.
+3. Write ops comment — **first line**: `**⚙️ Admin [role-admin-execution] — Addie Merges**`
+   then: `## Operations Evidence (#N)` including:
+   - PR URL and merge SHA
+   - CI check results (pass/fail per check name)
+   - Any post-merge actions (release, deploy, label update)
+4. Add ✅ reaction: `gh api repos/{owner}/{repo}/pulls/{PR}/reactions -f content=+1`
+5. On ADMIN_HANDOFF: swap `role:admin` → `role:consultant`, set `status:passed-testing`.
+6. **Emit event**: `emit-event.js --type baton:admin --issue N --role admin --agent "Addie Merges"`.
+
+## PASSED-TESTING gate
+
+`status:passed-testing` means the merge is **already complete**. Admin sets this status only after:
+- All CI gates green.
+- PR merged via `gh pr merge --squash --delete-branch`.
+- Post-merge event emitted.
+
+Do not set `passed-testing` before merge. Consultant receives the baton only after merge is confirmed.
+
+## Review-failed flow
+
+If AC verification fails: swap `status:in-review` → `status:review-failed`, swap `role:admin` → `role:collaborator`, uncheck failing ACs, comment reason. Collaborator re-implements.
+
+## Post-merge AC failure policy
+
+Never revert a merge. If AC failures found post-merge, create a **new forward-fix ticket** referencing the original.
+
 ## Entry criteria
 
 - `COLLABORATOR_HANDOFF` validation evidence is present.
@@ -23,24 +61,31 @@ disable-model-invocation: false
 
 - `ADMIN_HANDOFF` records objective outcomes for each operation.
 - Governance/release checks are marked complete or explicitly N/A.
+- **Merge-before-handoff** (#3053): for lane:code-change, when CI is green and
+  `admin_review_rating >= 93`, the PR MUST be merged before posting ADMIN_HANDOFF.
+  Red CI is never force-bypassed. Exceptions: `merge-evidence-override-approved`
+  label or `baseline_drift_override`. The Admin owns the merge; never route
+  merge authorization to the client (principle #2578).
 
 ## Must not do
 
 - Do not re-scope implementation.
 - Do not skip required validation evidence.
 
-## Escalation triggers
+## Merge verification checklist
 
-- Operational preconditions fail.
-- Release/governance integrity checks fail.
+1. Branch matches `<type>/<issue#>-<slug>` convention.
+2. Collaborator pulled latest `main` before PR (no stale base).
+3. Commit messages reference `#N` (issue number).
+4. Research tickets: no merge — verify findings posted as comment.
 
-## Output contract
+## Feature completion steps (required for feature/bugfix)
 
-```text
-ADMIN_HANDOFF
-operations_run:
-service_runtime_state:
-git_pr_release_state:
-governance_checks:
-exceptions_or_na:
-```
+Execute in order:
+1. **Commit** — `git add -A && git commit -m "... Closes #N"`
+2. **Push** — `git push -u origin <branch-name>`
+3. **PR** — `gh pr create` with `Closes #N`, evidence, labels
+4. **CI green** — `gh pr checks <PR> --watch`; fix before merge
+5. **Merge** — `gh pr merge --squash --delete-branch`
+6. **Event** — `emit-event.js '{"type":"pr:merged","ticket":"#N"}'`
+7. **Close** — `gh issue close N --comment "Released in vX.Y.Z"`

--- a/skills/role-baton-orchestrator/SKILL.md
+++ b/skills/role-baton-orchestrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: role-baton-orchestrator
-description: Orchestrate single-thread baton handoff across Manager -> Collaborator -> Admin -> Consultant with explicit entry/exit contracts.
-argument-hint: [context: new-task|post-failure|pre-merge|pre-release] [scope: code|ops|governance|mixed]
+description: "Orchestrate single-thread baton handoff across Manager -> Collaborator -> Admin -> Consultant with explicit entry/exit contracts."
+argument-hint: "[context: new-task|post-failure|pre-merge|pre-release] [scope: code|ops|governance|mixed]"
 user-invocable: true
 disable-model-invocation: false
 ---
@@ -12,14 +12,31 @@ disable-model-invocation: false
 
 Provide deterministic role sequencing for end-to-end tasks while preventing overlap and instruction drift.
 
-## Sequence (fixed)
+## Sequence (fixed, per ticket)
 
 1. Manager
 2. Collaborator
 3. Admin
 4. Consultant
 
-Only one role may be active at a time.
+Only one role may be active **per ticket** at a time.
+Multiple tickets may have different active roles concurrently.
+
+## Parallel dispatch
+
+Manager may hand off N tickets to N different collaborators simultaneously.
+Each ticket carries its own baton independently. Constraints:
+- Each collaborator owns exactly one ticket at a time.
+- Admin merges are serialized (one PR at a time) to avoid conflicts.
+- Collaborators pull latest main before creating PR.
+
+## Research ticket lifecycle
+
+Research tickets skip branch/PR/merge. Baton sequence:
+1. Manager: scope research question, assign collaborator (fleet LLM).
+2. Collaborator: produce research, post findings on ticket.
+3. Admin: review storage placement (wiki/research/), no merge.
+4. Consultant: validate quality, close ticket.
 
 ## Entry criteria
 

--- a/skills/role-collaborator-execution/SKILL.md
+++ b/skills/role-collaborator-execution/SKILL.md
@@ -15,33 +15,85 @@ disable-model-invocation: false
 - Run required validation gates and capture outcomes.
 - Update docs/changelog when behavior changes.
 
+## Upstream verification (from Manager)
+
+Before implementing, verify Manager's scope:
+- Are acceptance criteria testable and complete (binary pass/fail)?
+- Are constraints realistic given available resources?
+- Are verification gates achievable? If not, push back early.
+- If scope is vague, request `MANAGER_HANDOFF` revision.
+
 ## Entry criteria
 
 - Valid `MANAGER_HANDOFF` exists.
 - Required gates are defined.
+- Active GitHub issue linked to work.
+
+## Branch and commit rules
+
+- Create branch: `<type>/<issue#>-<slug>` (e.g., `feat/62-baton-redesign`).
+- Every commit references `#N` in message.
+- Pull latest `main` into branch before PR: `git pull origin main`.
+- Research tickets: no branch — post findings as ticket comment.
 
 ## Exit criteria
 
 - `COLLABORATOR_HANDOFF` includes concrete validation evidence.
+- `COLLABORATOR_HANDOFF` explicitly enumerates `admin_required_ops`.
+- Do not declare complete at exit; "all gates pass" = validated, not released.
 - Any scope drift is explicitly flagged for manager re-handoff.
 
-## Must not do
+## Rich comment template
 
+`COLLABORATOR_HANDOFF` comment must include:
+- **Changes**: per-file summary of what changed and why
+- **Behavior delta**: before/after description of observable behavior
+- **AC evidence**: each AC checkbox ✅ with the test command or output proving it
+- **Risks for Admin**: potential CI flags, merge conflict risk, env dependencies
+- **Visualization** (optional): Mermaid diagram or ASCII flow for complex changes
+
+Add 🔧 reaction: `gh api repos/{owner}/{repo}/issues/{N}/reactions -f content=wrench`
+
+## Multi-ticket TODO model
+
+When multiple tickets are in `status:todo`, the Collaborator:
+- Holds ALL of them in TODO simultaneously (visible in baton map).
+- Keeps **exactly one** in `status:in-progress` at a time.
+- Completes and emits `COLLABORATOR_HANDOFF` before pulling the next ticket to `in-progress`.
+
+This prevents context bleed and ensures clean per-ticket evidence trails.
+
+## Ticket baton protocol
+
+1. Write comment — **first line**: `**🔧 Collaborator [role-collaborator-execution] — <persona>**`
+   then: `## Validation Evidence (#N)`.
+2. Transition labels: `status:todo` → `status:in-progress`, confirm `role:collaborator`.
+3. **AC confirmation gate**: Before COLLABORATOR_HANDOFF, mark each AC checkbox ✅ or ❌ with evidence. All must be ✅ to proceed.
+4. On COLLABORATOR_HANDOFF: swap `role:collaborator` → `role:admin`.
+5. **Emit event**: `emit-event.js --type baton:collaborator --issue N --role collaborator --agent "<persona>"`.
+
+**Persona roster**: see `agents/roster.json`. Select persona matching task specialty.
+
+## Must not do
 - Do not alter scope without manager handoff update.
 - Do not perform final release/merge/admin governance decisions.
 
 ## Escalation triggers
-
 - Missing gate evidence.
 - Ambiguous acceptance criteria.
+## Pre-handoff verification (#1571)
 
+Run `runChecks()` from `scripts/global/collaborator-self-check.js` and
+paste the `formatChecks()` table into the handoff body before posting.
+Waiver: label `collaborator-self-check:waived`.
 ## Output contract
-
 ```text
 COLLABORATOR_HANDOFF
 files_changed:
 behavior_changes:
 validation_results:
 docs_updates:
+admin_required_ops:
 open_risks:
+pre_handoff_checks:
 ```

--- a/skills/role-consultant-critique/SKILL.md
+++ b/skills/role-consultant-critique/SKILL.md
@@ -8,39 +8,93 @@ disable-model-invocation: false
 
 # Role: Consultant Critique
 
+## Comprehensive Check Registry
+
+Run `node scripts/global/consultant-checks.js --issue <N> --json > /tmp/checks.json` before CLOSEOUT.
+Checks span 3 domains: `governance` (baton artifacts, labels, events), `tools` (wiki growth, skill refs), `fleet` (device routing, cost budget).
+Include `checks_run: <N>/<total>` and `checks_failed: <N>` in CLOSEOUT output.
+
 ## Responsibilities
 
-- Perform independent quality/risk review.
+- Perform independent quality/risk review of ALL prior roles.
 - Score confidence and identify residual risk.
+- **Grade Manager scope quality** — were gates testable and complete?
+- **Grade Collaborator implementation** — evidence per gate, no gold-plating?
+- **Grade Admin process** — clean deployment, proper git hygiene?
+- **Audit ticket governance, wiki generation, and fleet routing.**
 - Recommend follow-up actions with priority.
+- Identify at least one concrete improvement per role per review.
+
+## Grading rubric
+
+For G1-G9 harness goal scores, use the deterministic v2 rubric. Run
+`node scripts/global/rubric-score.js --trail <issue-trail> --diff <pr.diff>
+--closeout <closeout-draft>` and paste only its JSON under
+`### Deterministic Rubric`. Subjective scoring text belongs in
+`### Rationale` and must not affect `boxes_checked`, `boxes_total`, `score`, or
+`mean`. Legacy `G1=9, G2=8, ...` scoring remains accepted only through the
+2026-05-22 transition window.
+
+| Area | Pass | Fail |
+|---|---|---|
+| Scope testability | All gates have binary pass/fail | Vague gates ("make it good") |
+| Evidence completeness | Each gate has artifact | Missing gate results |
+| Process adherence | Branch, commit, PR, merge per protocol | Skipped steps |
+| Ticket governance | Issue exists, linked, labeled | No issue, orphan commits |
+| Comment protocol | Each role posted structured comment | Missing role comments |
+| Wiki growth | Research → wiki pages generated | Research with 0 wiki pages |
+| Fleet routing | Tasks use appropriate devices | All tasks on one device |
+
+## Ticket baton protocol (CLOSEOUT)
+
+1. Write CLOSEOUT — **first line**: `**🔍 Consultant [role-consultant-critique] — Quinn Critic**`
+   then: `## CLOSEOUT (#N)` with grades, risks, follow-ups.
+2. Transition labels: `status:passed-testing` → `status:done`, remove `role:*`.
+3. **Audit**: Verify each role posted a structured comment (Manager scope, Collaborator evidence, Admin ops).
+4. Add 🎉 emoji reaction to the issue to celebrate closure.
+5. **Emit event**: `emit-event.js --type baton:consultant --issue N --role consultant --agent "Quinn Critic"`.
+6. Close issue: `gh issue close N --comment "Released in vX.Y.Z — summary"`.
+7. **Manager Feedback Protocol**: after confidence scoring, run `node scripts/global/consultant-feedback.js --issue <N> --results /tmp/checks.json`. Require `remediation_issues: [...]` in CLOSEOUT if any FAIL (or `remediation_issues: none`).
+
+## Reject criteria (governance failures only)
+
+Reject (revert to Collaborator) only when a required artifact is absent, ACs lack evidence, or Admin merged before CI was green. Disagreements on quality/style become `recommended_follow_ups`. Post exact violation before rejecting.
 
 ## Entry criteria
 
-- `ADMIN_HANDOFF` exists (or explicit N/A with reason).
-- Evidence set is sufficient to support confidence scoring.
+- `ADMIN_HANDOFF` exists and evidence supports confidence scoring.
 
 ## Exit criteria
 
-- `CONSULTANT_CLOSEOUT` includes strengths, risks, and prioritized follow-ups.
-- Confidence score is evidence-backed.
+- `CONSULTANT_CLOSEOUT` includes per-role grades, evidence-backed confidence,
+  and at least one improvement per role.
 
 ## Must not do
 
 - Do not silently re-open implementation scope.
 - Do not claim certainty without evidence.
 
-## Escalation triggers
+## Drift detection checklist (mandatory)
 
-- Material evidence gaps.
-- High residual risk without mitigation path.
+- [ ] **Labels**: Issue has correct type/status/priority/area/role labels.
+- [ ] **Comments**: Each role posted structured comment (Mgr/Collab/Admin).
+- [ ] **Events**: Baton transitions emitted via emit-event.js at each handoff.
+- [ ] **ACs**: All acceptance criteria checked ✅ with evidence.
 
 ## Output contract
 
-```text
 CONSULTANT_CLOSEOUT
+manager_grade: <A-F> <justification>
+collaborator_grade: <A-F> <justification>
+admin_grade: <A-F> <justification>
+drift_score: <0-10> <evidence: events emitted / expected>
 strengths:
 findings:
 risk_register:
 confidence: <low|medium|high>
+wiki_health: <pages_before>→<pages_after>
+fleet_utilization: <devices_used>/<devices_available>
 recommended_follow_ups:
-```
+checks_run: <N>/<total>
+checks_failed: <N>
+remediation_issues: <list or none>

--- a/skills/role-manager-execution/SKILL.md
+++ b/skills/role-manager-execution/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: role-manager-execution
-description: Define scope, constraints, acceptance criteria, and verification gates before implementation begins.
-argument-hint: [task-type: feature|bugfix|refactor|governance] [risk: low|medium|high]
+description: "Define scope, constraints, acceptance criteria, and verification gates before implementation begins."
+argument-hint: "[task-type: feature|bugfix|refactor|governance] [risk: low|medium|high]"
 user-invocable: true
 disable-model-invocation: false
 ---
@@ -10,10 +10,41 @@ disable-model-invocation: false
 
 ## Responsibilities
 
+- Create or link a GitHub issue **before any other action**.
 - Clarify objective and non-objectives.
 - Identify constraints from instructions and repository policy.
-- Define objective acceptance criteria.
+- Define **testable** acceptance criteria (binary pass/fail only).
 - Select required gates/tests/checks.
+- Provide context, not step-by-step instructions (autonomy principle).
+
+## Upstream verification (from Consultant)
+
+Before starting new work, check if prior Consultant CLOSEOUT had recommendations:
+- Incorporate feedback from `recommended_follow_ups`.
+- Address any `process: ticket-hygiene-gap` findings.
+
+## Ticket-first gate (mandatory)
+
+Before emitting `MANAGER_HANDOFF`, the Manager **must**:
+
+1. Run `gh issue list` to check for an existing issue matching the task.
+2. If none exists: `gh issue create --title "<imperative>" --label "type:..." --label "status:backlog" --label "priority:..." --label "area:..."`.
+3. Record the issue number in `MANAGER_HANDOFF` as `issue: #N`.
+4. All subsequent commits must reference `#N` in the commit message.
+
+**Skip condition**: trivial-task escape (read-only, no file edits, no state changes).
+
+## Ticket baton protocol
+
+1. Write scope comment — **first line must be**: `**🎯 Manager [role-manager-execution] — Manny Scope**`
+   then: `## Scope Definition (#N)` with objective, AC, constraints.
+2. Each AC **must** be a binary pass/fail checkbox: `- [ ] AC1: <testable statement>`.
+3. Set labels: `status:todo`, `role:manager`.
+4. Add 👀 reaction via `gh api repos/{owner}/{repo}/issues/{N}/reactions -f content=eyes`.
+5. On MANAGER_HANDOFF: swap `role:manager` → `role:collaborator`.
+6. **Emit event**: `emit-event.js --type baton:manager --issue N --role manager --agent "Manny Scope"`.
+
+**Persona roster**: see `agents/roster.json` for all 9 named agents.
 
 ## Entry criteria
 
@@ -22,6 +53,7 @@ disable-model-invocation: false
 
 ## Exit criteria
 
+- A GitHub issue exists and is referenced in `MANAGER_HANDOFF`.
 - `MANAGER_HANDOFF` is complete and testable.
 - Scope boundaries are explicit enough for implementation without reinterpretation.
 
@@ -34,15 +66,23 @@ disable-model-invocation: false
 
 - If scope expands materially, regenerate `MANAGER_HANDOFF` before collaborator work continues.
 
-## Required integrations
+## BACKLOG vs TODO distinction
 
-- Route standards with `repo-standards-router`.
-- Use `workflow-self-anneal` only if post-failure/process drift applies.
+- **BACKLOG** (`status:backlog`): Ticket exists but Manager has NOT claimed it. Inactive-open. No role binding. Used for triage queue.
+- **TODO** (`status:todo`): Manager has claimed and is actively defining scope. Role binding = `role:manager`.
+
+Set `status:todo` (not `status:backlog`) when beginning a new Manager cycle.
+
+## Cancellation authority
+
+Manager is the **only role** that may cancel a ticket. Applies at **any status**.
+Required: post a comment with cancellation reason before setting `status:cancelled` and removing all role labels.
 
 ## Output contract
 
 ```text
 MANAGER_HANDOFF
+issue: #N
 objective:
 non_objectives:
 constraints:

--- a/skills/secret-exposure-prevention/SKILL.md
+++ b/skills/secret-exposure-prevention/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: secret-exposure-prevention
 description: Prevent secret leakage across git history, package artifacts, logs, and docs. Use when editing workflows, packaging configuration, environment files, or release automation.
+argument-hint: ""
+user-invocable: true
+disable-model-invocation: false
 ---
 
 # Secret Exposure Prevention

--- a/skills/workflow-self-anneal/SKILL.md
+++ b/skills/workflow-self-anneal/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflow-self-anneal
-description: Run a bounded self-annealing review of operating instructions and workflow outcomes. Use this after failures, after long sessions, before merge, or when repeated mismatches appear between intended process and observed execution.
-argument-hint: [context: session-start|post-failure|pre-merge|post-release] [scope: workflow|stability|qa|git]
+description: "Run a bounded self-annealing review of operating instructions and workflow outcomes. Use this after failures, after long sessions, before merge, or when repeated mismatches appear between intended process and observed execution."
+argument-hint: "[context: session-start|post-failure|pre-merge|post-release] [scope: workflow|stability|qa|git]"
 user-invocable: true
 disable-model-invocation: false
 ---
@@ -16,49 +16,44 @@ This skill optimizes _process reliability_, not model internals.
 
 ## Hard safety constraints
 
-1. No unbounded loops, recursive retries, or autonomous "improve forever" behavior.
-2. Maximum one anneal pass per invocation.
-3. Maximum three proposed documentation changes per invocation.
-4. Do not claim deploy/publish/release success without explicit verification evidence.
-5. Do not modify security/permission policy automatically; propose changes only.
-6. If evidence is insufficient, return `NO_CHANGE` with missing-evidence requirements.
+1. No unbounded loops or autonomous "improve forever" behavior.
+2. Max one anneal pass per invocation; max three proposed doc changes.
+3. No deploy/publish success claims without verification evidence.
+4. Do not modify security/permission policy automatically; propose only.
+5. If evidence insufficient, return `NO_CHANGE` with missing-evidence list.
 
 ## Trigger conditions
 
-Run this skill when any of the following is true:
+- Same failure pattern ≥2 times in 7 days.
+- Session crash/restart/tooling instability.
+- Instructions contradicted by observed actions.
+- Pre-merge gate requires hardening evidence.
+- Repeated carryover/blocked items across iterations.
+- PR/merge latency breaches targets or reopened issues trend up.
+- **Commits exist without linked GitHub issues** (process drift).
+- **Consultant check registry returns ≥1 FAIL on domain:governance**.
+- **Fleet check `fleet-002` (cost-budget) FAIL for ≥2 consecutive cycles**.
 
-- Same failure pattern appears at least twice in the last 7 days.
-- Session had crash/restart/tooling instability.
-- Instructions were contradicted by observed actions.
-- Pre-merge gate requires process hardening evidence.
-- Repeated carryover/blocked items appear across iterations.
-- PR review or merge latency repeatedly breaches team targets.
-- Reopened issues/defects trend upward.
+## Consultant Integration
+
+Self-anneal may be invoked automatically from `consultant-feedback.js` when `gov-002` (baton-artifact-presence) or `gov-003` (event-emission) FAIL — these are workflow process failures, not implementation bugs.
+Check IDs are managed in `scripts/global/consultant-checks.js` (3 domains: governance/tools/fleet).
 
 ## Input collection
 
-Collect only relevant evidence for current scope:
-
-- Recent execution artifacts (logs, errors, failing checks, screenshots, QA notes)
-- Existing instructions and workflow docs
-- Recent commits/PR notes if available
-
-If required artifacts are unavailable, declare exactly what is missing and stop.
+Collect: execution artifacts (logs, errors, checks), instructions/workflow docs, recent commits/PR notes. If unavailable, declare missing and stop.
 
 ## Analysis protocol
 
-1. **Detect mismatch**
-   - Compare expected behavior from instructions vs observed behavior in evidence.
-2. **Classify root cause**
-   - One of: `ambiguity`, `missing guardrail`, `stale instruction`, `tool fragility`, `human override`.
-3. **Assess recurrence risk**
-   - `low`, `medium`, `high` based on frequency and blast radius.
-4. **Detect Agile drift signals**
-   - Check trend indicators (carryover, blocked age, review latency, reopen rate).
-5. **Propose minimal fix**
-   - Prefer smallest docs/workflow delta that prevents recurrence.
-6. **Define verification gate**
-   - Add objective checks that confirm the fix works.
+1. **Detect mismatch**: expected vs observed behavior.
+2. **Classify root cause**: `ambiguity|missing guardrail|stale instruction|tool fragility|human override`.
+3. **Assess recurrence risk**: `low|medium|high` by frequency and blast radius.
+4. **Detect Agile drift signals**: carryover, blocked age, review/merge latency, reopen rate.
+   - **Ticket linkage**: `git log --oneline | wc -l` vs `--grep='#'`. If <80%, flag `ticket-linkage-drift`.
+   - **PR coverage**: commits vs `gh pr list --state all`. If 0 PRs, flag `pr-coverage-drift`.
+   - **Event gaps**: count events in `.dashboard/events.jsonl` per role transition. If <1 event per baton handoff, flag `event-emission-drift`.
+5. **Propose minimal fix**: smallest docs/workflow delta preventing recurrence.
+6. **Define verification gate**: objective checks confirming the fix.
 
 ## Output format (required)
 
@@ -68,77 +63,36 @@ Return exactly this structure:
 SELF_ANNEAL_REPORT
 context: <session-start|post-failure|pre-merge|post-release>
 scope: <workflow|stability|qa|git>
-
-observation:
-- ...
-
-expected_behavior:
-- ...
-
-mismatch:
-- ...
-
+observation: [...]
+expected_behavior: [...]
+mismatch: [...]
 root_cause: <ambiguity|missing guardrail|stale instruction|tool fragility|human override>
 risk: <low|medium|high>
-
 drift_signals:
-- metric: <carryover|blocked-age|review-latency|merge-latency|reopen-rate>
-   trend: <improving|stable|degrading>
-   evidence: <artifact reference>
-
+- metric: <carryover|blocked-age|review-latency|merge-latency|reopen-rate|ticket-linkage|pr-coverage>
+   trend: <improving|stable|degrading>  evidence: <artifact>
 proposed_changes:
-1) file: <path>
-   change_type: <add|edit|remove>
-   rationale: <why this is minimal and sufficient>
-   patch_summary: <short description>
-
+1) file: <path>  change_type: <add|edit|remove>  rationale: <why>
 verification_plan:
-- check: <objective check>
-  pass_condition: <measurable condition>
-
-decision:
-- <apply|defer|NO_CHANGE>
-
-missing_evidence:
-- <none or required artifacts>
+- check: <objective>  pass_condition: <measurable>
+decision: <apply|defer|NO_CHANGE>
+missing_evidence: <none or list>
 ```
 
 ## Change targeting guidance
 
-When possible, prioritize these targets:
-
-1. `docs/workflow/self-annealing.md`
-2. `docs/workflow/learnings.md`
-3. `docs/technical/system-stability.md`
-4. `docs/workflow/skills/AGILE-METRICS-PLAYBOOK.md`
-5. project-specific runbooks/checklists directly tied to failure mode
+Prioritize: project runbooks/checklists, workflow docs, system-stability docs, learnings docs.
 
 ## Stop conditions
 
-Stop immediately and return `NO_CHANGE` if:
+Return `NO_CHANGE` if: change cannot be validated objectively, evidence is missing, change expands permissions, or same fix was already applied.
 
-- Proposed change cannot be validated objectively.
-- Required evidence is missing.
-- Change would expand permissions or bypass approval controls.
-- The same recommendation was already applied and verified recently.
+For iterative anneal loops (refinement passes), call `shouldStop(...)` from `scripts/global/anneal-stop.js` after every iteration (Epic #1568 AC-5, #1574). Stop when: deterministic gates green, OR `iterations >= 3`, OR `|rubric_mean_delta| <= 0.5`. Continuation past a stop requires `ANNEAL_OVERRIDE_CONTINUE: rationale` comment from the operator and is logged as `event:kill-switch-bypass`.
 
 ## Quality bar
 
-A good anneal output is:
+Good anneal output is: **specific** (concrete artifacts), **minimal** (smallest viable delta), **testable** (pass/fail checks), **traceable** (rationale + risk), **trend-aware** (drift reducing).
 
-- **Specific**: references concrete behavior and artifacts
-- **Minimal**: smallest viable guardrail update
-- **Testable**: clear pass/fail checks
-- **Traceable**: explicit rationale and risk classification
-- **Trend-aware**: confirms drift is reduced across subsequent cycles
+## Visual verification rule (publish/UX scope)
 
-## Mandatory visual verification rule (publish/UX scope)
-
-When scope includes UX-rendered changes (`qa` or `workflow` affecting UI):
-
-1. Do not allow ticket closure or publish success claims from DOM/CI checks alone.
-2. Require at least one post-change visual inspection artifact (Claude Vision or equivalent) from live/UAT.
-3. Required pass evidence in `verification_plan`:
-   - `check`: visual rendering integrity
-   - `pass_condition`: primary hero/content sections visibly render, primary CTA visible, no major collapse/malformed layout
-4. If evidence is missing, decision must be `NO_CHANGE` or `defer` with explicit missing artifact list.
+For UX-rendered changes: require post-change visual inspection artifact. Do not allow ticket closure from DOM/CI checks alone. If visual evidence is missing, decision must be `defer`.

--- a/wiki/work-log/ticket-3801/admin-handoff.md
+++ b/wiki/work-log/ticket-3801/admin-handoff.md
@@ -1,0 +1,26 @@
+# #3801 — baseline capture · ADMIN HANDOFF
+
+> Baton role: **Admin**. Merge execution for the cleanup lane.
+
+## Merge decision (autonomy-vs-escalate — G8)
+
+- Target: `main` — **unprotected** (mirror of public origin; PRs #6/#9/#10/#11/#12 merged here).
+- Change class: **reversible** faithful snapshot of already-running guards; **not** security-weakening.
+- Retained carve-outs (protected-main / production / irreversible / security-weakening / UAT / design):
+  **none triggered.** ⇒ Complete the reversible push→PR→merge **autonomously**. Logged here (G8).
+
+## Mirror-ticket Admin semantics (#3799-AC3 precedent)
+
+No live GitHub issue (#3801 is wiki-mirror; issue space caps at #5). Therefore:
+- PR body cites the mirror path `wiki/work-log/tickets/3801.md` in lieu of `Closes #N`.
+- Mirror-close = commit `wiki/work-log/tickets/3801.md` with `status: DONE` (done on this branch).
+
+## Checklist
+
+- [x] Manager scope committed before edits (`0f18254`).
+- [x] Faithful capture committed (`b1cc728`), content-only diff, 39/39 cmp-clean.
+- [x] Collaborator hermetic validation (4 hooks py_compile green on clean `.git`-less tree).
+- [x] Consultant ACCEPT + cross-family PASS receipt `b190be5c137642bb` (meta + mistral).
+- [ ] Push branch → open PR (mirror-path body) → CI green → merge to `main`.
+- [ ] Release claim `claim/cleanup-3801-baseline-capture` (from non-merged cwd).
+- [ ] Prune merged feature branch; MEMORY.md note; `git worktree remove`.

--- a/wiki/work-log/ticket-3801/capture-manifest.md
+++ b/wiki/work-log/ticket-3801/capture-manifest.md
@@ -1,0 +1,92 @@
+# #3801 — 39-file baseline capture · ATTRIBUTION MANIFEST (AC2)
+
+> Collaborator artifact. Faithful snapshot of the canonical checkout's live working-tree drift
+> (`~/copilot-governance`, parked on `feat/3026`). Diff on `cleanup/3801-baseline-capture`:
+> **39 files, +2159 / −607**, byte-identical to source (39/39 `cmp` clean). **No behavioral edits.**
+>
+> Attribution is **best-effort forensic** — ticket refs mined from added lines (`#NNNN`), themes from
+> salient added content. Drift is genuinely multi-ticket (25+); `—` = no embedded ref, theme inferred.
+
+## Subsystem A — Session hooks (runtime security-guard logic) · `hooks/scripts/*.py`  (+1114 net-heavy)
+
+| File | Δ | Cited refs | Nature of change |
+|------|----|-----------|------------------|
+| `pretool_guard.py` | +793 | #3392, #3569, #2995 | Largest driver. Pre-tool baton/ticket/branch gate + session-anomaly + admin-pattern enforcement expansion. The running guard this whole roadmap keys off. |
+| `stop_reminder.py` | ~+150 | #3569, #3749, #3266 | Stop-hook completeness/baton-incomplete messaging; session-cwd branch cleanliness checks. |
+| `posttool_reminders.py` | ~+107 | — | PostToolUse governance/docs-hygiene reminders + context re-injection; shared-dir `sys.path` bootstrap. |
+| `session_context.py` | ~+64 | — | SessionStart project-type adaptive governance context injection; `sys.path` bootstrap. |
+
+## Subsystem B — Governance instructions · `instructions/*.md`  (largest doc block)
+
+| File | Δ | Cited refs | Nature of change |
+|------|----|-----------|------------------|
+| `role-baton-routing.instructions.md` | +420 | #1828, #2148, #3532 | Baton lane routing / lightweight-lane + role-completion rules (aligns with #2263/#2345 lane reality). |
+| `global-standards.instructions.md` | +115 | #2355, #2399, #3391 | Goal-lens G1-G10, operator-autonomy carve-out taxonomy, decision-check discipline. |
+| `workflow-resilience.instructions.md` | ~+96 | #2116, #3380, #2113 | Tier-2 mid-flight anneal-emission model; goal-failure-escalation events. |
+| `github-governance.instructions.md` | ~+55 | #2304, #2295, #1614 | GitHub ticket/PR governance gate wording. |
+| `operator-identity-context.instructions.md` | ~+56 | #3714, #1889 | Operator identity/consensus-routing context (self-post closeout → consensus). |
+| `release-docs-hygiene.instructions.md` | ~+26 | #999, #2148 | Release/docs hygiene cadence. |
+| `repo-health-onboarding.instructions.md` | ~+17 | — | OpenSSF alignment (Dependabot/secret-scanning/scorecard); session-start profile skill. |
+| `playwright-mcp-low-resource.instructions.md` | +2/−2 | — | Path normalization for preflight script. |
+
+## Subsystem C — Skills bodies · `skills/*/SKILL.md`  (22 files)
+
+| File | Δ | Cited refs | Nature of change |
+|------|----|-----------|------------------|
+| `github-ticket-lifecycle-orchestrator/SKILL.md` | ~184 | — | Baton/lifecycle phase-protocol evolution (largest skill Δ). |
+| `workflow-self-anneal/SKILL.md` | ~136 | #1574, #1568 | Bounded self-anneal review procedure. |
+| `operator-identity-context/SKILL.md` | ~85 | — | Operator-identity adapter refresh. |
+| `role-consultant-critique/SKILL.md` | ~74 | — | Consultant critique/risk-scoring procedure. |
+| `role-admin-execution/SKILL.md` | ~73 | #3053, #2578 | Admin merge/handoff execution steps. |
+| `role-collaborator-execution/SKILL.md` | ~58 | #1571 | Collaborator evidence-gate procedure. |
+| `role-manager-execution/SKILL.md` | ~52 | — | Manager scope/AC/gate definition procedure. |
+| `docs-drift-maintenance/SKILL.md` | ~40 | #101 | Docs-drift detect/remediate procedure. |
+| `role-baton-orchestrator/SKILL.md` | ~25 | — | Baton entry/exit contract orchestration. |
+| `repo-onboarding-standards/SKILL.md` | ~21 | #2785 | Repo onboarding baseline. |
+| `repo-standards-router/SKILL.md` | ~19 | — | App-type → standards-branch routing. |
+| `github-actions-security-hardening/SKILL.md` | +11 | — | Least-privilege/pinning posture additions. |
+| `mem-watchdog-ops/SKILL.md` | ~10 | — | Memory watchdog ops adapter. |
+| `github-{ops-excellence,ops-tree-router,projects-agile-linkage,release-incident-flow,review-merge-admin}/SKILL.md` | ~4 each | — | GitHub-ops skill-tree cross-reference/routing touch-ups. |
+| `{repo-profile-governance,playwright-vision-low-resource}/SKILL.md` | ~4 each | — | Adapter/path refresh. |
+| `{release-version-integrity,secret-exposure-prevention}/SKILL.md` | +3 each | — | Additive guidance lines. |
+
+## Subsystem D — Agent cards · `agents/*.md`  (4 files)
+
+| File | Δ | Nature of change |
+|------|----|------------------|
+| `planner.agent.md` | ~10 | Model pin `Claude Opus 4.6 (copilot)` + prompt-action wiring (Implement/Architect). |
+| `security-scanner.agent.md` | ~4 | Model pin `Sonnet 4.6` + secret-pattern list. |
+| `governance-auditor.agent.md` | +2/−2 | Model pin normalization. |
+| `release-reviewer.agent.md` | +2/−2 | Model pin normalization. |
+
+## Subsystem E — Repo config · `.gitignore`  (+25)
+
+| File | Cited refs | Nature of change |
+|------|-----------|------------------|
+| `.gitignore` | #3797 | Ignore rules from the baseline-restore era (session/HAMR/scratch artifacts). |
+
+## Provenance / safety attestation
+
+- Base = `origin/main` @ `5c898a7`. Verified this run that all 39 files are **disjoint** from the entire
+  `feat/3026`-vs-`main` committed diff ⇒ `main` content == `feat/3026` content for these files ⇒ the
+  branch diff is exactly the working-tree drift, nothing conflated.
+- `reset --hard` was **rejected** as remediation (would revert running guards). Capture-as-baseline chosen.
+- Untracked files (~724) deliberately **excluded** — documented-normal mirror state.
+
+## Mode normalization (sole deviation from a raw copy — corrects a capture-tool artifact, not drift)
+
+The initial `install`-based copy set 0755 on all 39 files. Verified against the canonical git index:
+docs/config source mode is **100644**, only the 4 `hooks/scripts/*.py` are legitimately **100755**.
+Modes were normalized to match the canonical index exactly ⇒ the committed diff is **content-only, no
+mode changes** (`git diff --cached | grep -c 'new mode'` = 0). Content remains 39/39 `cmp`-clean.
+
+## ⚠ Decision flagged for cross-family ratification (AC4) — `.gitignore` `wiki/` ignore
+
+The captured `.gitignore` (faithful) adds `wiki/` to the ignore set with the rationale "Generated
+LLM-wiki mirror (Karpathy-pattern, regenerated; never tracked)". This aligns with the ratified
+mirror-cutover direction (Epic #3719 / `ticket-universe-is-local-mirror`). Consequence: the 18 wiki
+files already tracked on `main` **stay tracked** (git does not untrack), but **new** baton artifacts
+under `wiki/` must be `git add -f`'d. This capture force-adds its own baton artifacts accordingly. This
+behavioral consequence is put to the cross-family panel rather than decided unilaterally; the
+`.gitignore` also ignores runtime/generated state and host-local token files (`/config.json`, `/ide/`,
+`/permissions-config.json`, #3797) — both unambiguously beneficial.

--- a/wiki/work-log/ticket-3801/collaborator-validation.md
+++ b/wiki/work-log/ticket-3801/collaborator-validation.md
@@ -1,0 +1,30 @@
+# #3801 — baseline capture · COLLABORATOR VALIDATION (evidence)
+
+> Baton role: **Collaborator**. Gates from Manager scope AC1/AC2/AC3.
+
+## AC1 — faithful snapshot (content byte-identical)
+
+- 39 files copied from canonical checkout working tree → branch. `cmp -s` per file: **39/39 identical**.
+- Branch changeset == exactly the 39-file drift list (`comm -23` of changed-vs-list = empty).
+- Diffstat: **39 files, +2159 / −607** — byte-matches the canonical checkout's `git diff HEAD`.
+- Modes normalized to the canonical git index (docs/config 100644, `.py` hooks 100755) ⇒ committed diff
+  is **content-only, 0 mode changes**. (See manifest "Mode normalization".)
+
+## AC2 — attribution manifest
+
+`capture-manifest.md` groups all 39 into 5 subsystems (hooks / instructions / skills / agents / config)
+with per-file Δ, mined `#NNNN` refs, and one-line change nature. Best-effort forensic; `—` = inferred.
+
+## AC3 — hermetic verification (clean, `.git`-less tree; node-built-ins/stdlib only)
+
+- Extracted the tracked tree to `/tmp/ci-3801` (126 files, **`.git` absent** — confirmed clean tree).
+- `python3 -m py_compile` on all 4 captured hooks
+  (`pretool_guard`, `stop_reminder`, `posttool_reminders`, `session_context`): **ALL 4 OK**.
+- No network, no `gh`, no untracked deps used. Captured docs/skills/instructions/agents are static
+  Markdown (no executable surface); the only executable surface in scope = the 4 hooks (compiled green).
+
+## Notes for Consultant / Admin
+
+- This is a **reversible** capture to **unprotected** `main` (no security-weakening — faithful snapshot
+  of already-running guards). Autonomy default applies; no retained carve-out triggered (G8).
+- One decision flagged for the panel: the `.gitignore` `wiki/` ignore (see manifest ⚠ section).

--- a/wiki/work-log/ticket-3801/consultant-closeout.md
+++ b/wiki/work-log/ticket-3801/consultant-closeout.md
@@ -1,0 +1,31 @@
+# #3801 — baseline capture · CONSULTANT CLOSEOUT (independent critique)
+
+> Baton role: **Consultant**. Post-execution critique; no implementation scope change.
+
+## Verdict: **ACCEPT** — capture is faithful, safe, and correctly scoped.
+
+## Cross-family ratification
+
+`cross-family-consensus.js --ticket 3801 --kind review` → **consensus PASS**, receipt
+**`b190be5c137642bb`**, families **meta** (groq) + **mistral** (2 distinct, non-authoring). Ratifies:
+(1) capture-as-baseline over discard; (2) faithful snapshot; (3) `.gitignore` `wiki/`-ignore consequence
+acceptable for a baseline PR. (Ollama free fleet not used — memory `free-fleet-cpu-bound`; cloud panel used.)
+
+## Risk assessment
+
+| Risk | Sev | Mitigation / disposition |
+|------|-----|--------------------------|
+| Capturing a behavioral change disguised as "snapshot" | Med | Content 39/39 `cmp`-clean; modes normalized to canonical index; diff is content-only. No edits. |
+| Base conflation (feat/3026 commits vs drift) | Med | Verified drift is **disjoint** from the full feat/3026-vs-main committed diff ⇒ base==main is exact. |
+| `.gitignore` `wiki/` ignore alters baton-artifact workflow | Low-Med | Already-tracked wiki files stay tracked; new artifacts force-add; aligns with ratified mirror-cutover (#3719). Panel-ratified. Follow-up may revisit if force-add friction proves costly. |
+| Running-guard regression from re-tracking | Low | Faithful snapshot of *already-running* logic; 4 hooks `py_compile`-green on clean tree. No logic change. |
+| Silent revert of live guards (the DANGEROUS path) | — | **Avoided** — `reset --hard` explicitly rejected; capture chosen. |
+
+## Residual / follow-ups (not blocking this merge)
+
+- Re-parking the canonical `~/copilot-governance` checkout onto post-merge `main` so its working tree
+  goes clean is a **separate** step (owned outside this cleanup; §6 forbids mutating the shared checkout here).
+- If `wiki/` force-add friction is material, a follow-up ticket can split the `.gitignore` `wiki/` line
+  from the runtime/token ignores.
+
+## Recommendation: **merge** (reversible, unprotected main, no carve-out triggered — G8 autonomous).

--- a/wiki/work-log/ticket-3801/manager-scope.md
+++ b/wiki/work-log/ticket-3801/manager-scope.md
@@ -1,0 +1,50 @@
+# #3801 — 39-file live-harness baseline capture · MANAGER SCOPE
+
+> Baton role: **Manager** | Lane: cleanup (own `claim/cleanup-3801-baseline-capture`) | Branch: `cleanup/3801-baseline-capture` off `origin/main` (5c898a7)
+> Mirror ticket: [wiki/work-log/tickets/3801.md](../tickets/3801.md) — no live GitHub issue (issue space caps at #5)
+
+## Problem (paid-for correction, not re-derived)
+
+The canonical checkout `~/copilot-governance` (parked on `feat/3026` @ `a15fe38`) carries **39 modified
+tracked files** = **+2159 / −607** of *live, running* harness logic that exists on **no branch**. This is
+**multi-ticket baseline drift** (pretool_guard/session_context/stop_reminder/posttool_reminders hooks,
+role-baton-routing + workflow-resilience + global-standards instructions, 22 skills, 4 agent cards,
+.gitignore). Prior sessions established (see memory `3026-drift-is-live-harness-baseline-not-3026`,
+`git-baseline-restore-3797`):
+
+- These 39 files are **NOT** `#3026` edits — **zero overlap** with `a15fe38`, and (verified this run)
+  **disjoint** from the entire `feat/3026`-vs-`main` committed diff. Therefore for these 39 files
+  `feat/3026` HEAD content **==** `main` content, so `main` is the correct capture base.
+- `reset --hard` / discard is **DANGEROUS** — it would silently revert running security-guard logic
+  (e.g. `pretool_guard.py` +793). The remediation is **CAPTURE-AS-BASELINE**, not discard.
+- The ~724 untracked files are **NORMAL** mirror state and are **OUT OF SCOPE** for this capture.
+
+## Scope (exactly these 39 files — see `capture-manifest.md` for the enumerated list + per-file attribution)
+
+Capture the live working-tree content of the 39 modified tracked files onto this branch verbatim, so
+the running harness logic becomes tracked baseline on `main`. **No behavioral edits** — this is a
+faithful snapshot; the diff on this branch must byte-match the canonical checkout's working tree.
+
+## Acceptance criteria
+
+- [ ] AC1 — All 39 files' live working-tree content is committed on this branch and byte-identical to
+      the canonical checkout (verified by `diff` of each file; manifest records sha of each).
+- [ ] AC2 — Per-file attribution manifest (`capture-manifest.md`): each file → likely owning ticket/theme
+      + one-line nature-of-change, grouped by subsystem. Best-effort forensic; unknowns marked.
+- [ ] AC3 — Hermetic verification GREEN on a clean, `.git`-less archive: the captured Python hooks
+      compile (`py_compile`) and the changed `scripts/*` specs (none in scope) — scope is hooks +
+      docs, so hermetic check = `python -m py_compile` on the 4 hook scripts + a `git archive | tar`
+      clean-tree extraction that reproduces the exact bytes.
+- [ ] AC4 — Cross-family consensus (≥2 distinct families, PASS) ratifies the *capture-as-baseline*
+      decision (vs discard) and that the snapshot is faithful; receipt cited.
+- [ ] AC5 — PR → CI-green → merged to `main` (reversible; `main` unprotected). Mirror ticket 3801
+      flipped to `status: DONE`. Claim released. MEMORY.md note added.
+
+## Non-goals / carve-outs
+
+- No re-parking or mutation of the canonical `~/copilot-governance` checkout (another session's shared
+  live checkout; §6). Its dirtiness is documented-normal until a separate re-park step.
+- No behavioral change to any captured file. No touching the 724 untracked files.
+- Not a security-weakening change (faithful snapshot of already-running guards) ⇒ **reversible**,
+  autonomous completion authorized (G8 autonomy-vs-escalate: reversible feature-branch push + PR + merge
+  to *unprotected* main = autonomous; no retained carve-out triggered).

--- a/wiki/work-log/tickets/3801.md
+++ b/wiki/work-log/tickets/3801.md
@@ -6,7 +6,7 @@ created: "2026-07-14"
 updated: "2026-07-14"
 tags: [issue, wiki-b, cleanup, drift-remediation]
 related: [3026, 3797, 2345, 3800, 2995, 3392, 3471]
-status: OPEN
+status: DONE
 source_path: "github:issue/3801"
 source_sha256: local-mirror-pending-real-issue
 content_hash: local-mirror-pending-real-issue
@@ -15,7 +15,12 @@ generated_by_run: local
 ---
 # #3801 — cleanup: reconcile the 39-file live-harness baseline drift (misattributed to #3026)
 
-> **Source**: local wiki-mirror (no live GitHub issue; real issue space maxes at #5) | **state: OPEN**
+> **Source**: local wiki-mirror (no live GitHub issue; real issue space maxes at #5) | **state: DONE**
+>
+> **CAPTURE EXECUTED** on `cleanup/3801-baseline-capture`: 39 files, +2159/−607, faithful content
+> snapshot (39/39 cmp-clean, modes normalized to canonical index, content-only diff). Base==main
+> (drift disjoint from feat/3026 commits). Baton complete; cross-family PASS receipt `b190be5c137642bb`
+> (meta+mistral). See `wiki/work-log/ticket-3801/{manager-scope,capture-manifest,collaborator-validation,consultant-closeout,admin-handoff}.md`.
 > **Labels**: type:cleanup, status:backlog, priority:P1, area:governance, area:hooks, lane:code-change,
 > drift-remediation, owner:E3-baseline
 > **Cleanup claim**: `claim/cleanup-harness-baseline-drift` (own branch; NEVER absorbed into a feature ticket)


### PR DESCRIPTION
## #3801 — 39-file live-harness baseline capture (mirror ticket)

Mirror ticket: `wiki/work-log/tickets/3801.md` (no live GitHub issue; issue space caps at #5). No `Closes #N` — mirror close = that file flipped to `status: DONE` in this PR.

### What
Capture-as-baseline of the multi-ticket working-tree drift carried on the canonical checkout (`feat/3026`) but present on **no branch**: session hooks (`pretool_guard.py` +793, `session_context`, `stop_reminder`, `posttool_reminders`), 8 governance instructions, 22 skill bodies, 4 agent cards, `.gitignore`. **+2159 / −607**, byte-identical content (39/39 `cmp`-clean), modes normalized to the canonical git index ⇒ **content-only diff**. **No behavioral edits.**

### Why capture, not discard
`reset --hard` would **silently revert running security-guard logic**. Roadmap §4.i mandates capture-as-baseline. Verified the drift is **disjoint** from the full `feat/3026`-vs-`main` committed diff ⇒ `main` is the exact base (nothing conflated with `#3026`).

### Evidence
- Faithful: 39/39 `cmp`-clean; branch changeset == exactly the drift list; 0 mode changes.
- Hermetic (clean `.git`-less tree): `py_compile` of all 4 hooks **green**.
- Cross-family consensus **PASS**, receipt `b190be5c137642bb` (families: meta/groq + mistral).
- Baton: Manager → Collaborator → Consultant (ACCEPT) → Admin — all under `wiki/work-log/ticket-3801/`.

### Flagged (panel-ratified)
Captured `.gitignore` adds `wiki/` (regenerated-mirror direction, #3719) + runtime-state + host-local token ignores (#3797). Already-tracked wiki files stay tracked; new baton artifacts force-add.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
