### PR TITLE
feat(#3800): AC3 Epic-close-time remediation hint (reuse-first extension)

### DIFF
--- a/docs/howto/epic-child-baton-traceability.md
+++ b/docs/howto/epic-child-baton-traceability.md
@@ -44,6 +44,25 @@ Give the flagged child its own `## CONSULTANT_CLOSEOUT` and `## GitHub Evidence 
 or reopen it and complete its baton. For a closed Epic with an open child (EB3), either close the child
 with its own evidence or reopen the Epic.
 
+## Close-time remediation hint (AC3)
+
+Before closing an Epic, ask the detector for an epic-scoped, actionable hint that names the specific
+children still missing their own baton evidence:
+
+```
+node scripts/epic-child-baton-traceability.js --epic <N>
+```
+
+- If the Epic has un-evidenced or still-open children, it prints a `CLOSE-TIME HINT` naming each
+  blocking child and the invariant codes (`EB1`/`EB2`/`EB3`) blocking it — remediate those first.
+- If the Epic is clean (or is not an actually-closing Epic), it prints `clear to close` and does
+  nothing else. The hint reuses the same validated `auditEpics()` predicate, so it is low-false-
+  positive by construction and **never** fires on an open/non-epic ticket.
+
+This is a HINT for the Manager/Admin baton path, not a blocking gate (advisory-first, always exit 0).
+Programmatic callers can use the exported `epicCloseHint(tickets, epicNumber)` →
+`{ epic, blockers:[{child, codes}], hint }` (`hint` is `null` when clear).
+
 ## Promotion path (not yet blocking)
 
 Promotion of any invariant from advisory to a hard Epic-close gate requires the AC4 shadow metric

--- a/scripts/epic-child-baton-traceability.js
+++ b/scripts/epic-child-baton-traceability.js
@@ -62,6 +62,41 @@ function auditEpics(tickets) {
   return { warnings };
 }
 
+// AC3 (#3800 Phase-1) — Epic-CLOSE-TIME remediation hint.
+// Given the ticket set and a SPECIFIC Epic being closed (Manager/Admin baton path),
+// reuse `auditEpics()` and return an actionable, epic-scoped hint that NAMES the
+// un-evidenced / open children the closer must remediate FIRST.
+// Pure. Returns { epic, blockers:[{child, codes:[...]}], hint }. `hint` is null and
+// `blockers` empty when the epic is clean OR is not an actually-closing Epic — no noise,
+// low-FP by construction (same validated predicate as the Phase-0 detector).
+// Advisory only: this is a HINT, never a blocking gate (promotion to blocking is AC4).
+function epicCloseHint(tickets, epicNumber) {
+  const n = Number(epicNumber);
+  const list = Array.isArray(tickets) ? tickets : [];
+  const epic = list.find((t) => t.number === n);
+  const empty = { epic: n, blockers: [], hint: null };
+  // Only meaningful for an actual Epic that is closed/closing.
+  if (!epic || String(epic.type || '').toLowerCase() !== 'epic' || !isClosed(epic.status)) return empty;
+  // Reuse the validated audit; keep only THIS epic's warnings.
+  const warnings = auditEpics(list).warnings.filter((w) => w.epic === n && w.child != null);
+  if (warnings.length === 0) return empty;
+  // Group by child → the set of invariant codes blocking that child.
+  const byChild = new Map();
+  for (const w of warnings) {
+    if (!byChild.has(w.child)) byChild.set(w.child, []);
+    byChild.get(w.child).push(w.code);
+  }
+  const blockers = [...byChild.entries()]
+    .map(([child, codes]) => ({ child, codes: codes.slice().sort() }))
+    .sort((a, b) => a.child - b.child);
+  const names = blockers.map((b) => `#${b.child}`).join(', ');
+  const hint =
+    `Epic #${n} is closing with ${blockers.length} un-evidenced child(ren): ${names}. ` +
+    'Before closing, give each child its own CONSULTANT_CLOSEOUT + GitHub Evidence Block ' +
+    '(or reopen/complete the open child). Per-child baton evidence is required — do not bundle-close.';
+  return { epic: n, blockers, hint };
+}
+
 // ── Mirror parsing (CLI only) ────────────────────────────────────────────────
 function parseMirrorTicket(file, txt) {
   const number = Number((path.basename(file).match(/(\d+)/) || [])[1] || 0);
@@ -85,8 +120,26 @@ function scanMirror(dir) {
     .map((f) => parseMirrorTicket(f, fs.readFileSync(path.join(dir, f), 'utf8')));
 }
 
-function main() {
+function main(argv) {
+  const args = argv || process.argv.slice(2);
   const dir = path.join(__dirname, '..', 'wiki', 'work-log', 'tickets');
+
+  // AC3 close-time hint mode: `--epic <N>` prints the epic-scoped remediation hint.
+  const epicIdx = args.indexOf('--epic');
+  if (epicIdx !== -1) {
+    const epicNumber = Number(args[epicIdx + 1]);
+    const { hint, blockers } = epicCloseHint(scanMirror(dir), epicNumber);
+    if (hint) {
+      console.log(`[epic-child-baton-traceability] CLOSE-TIME HINT for Epic #${epicNumber}:`);
+      console.log(`  ⚠ ${hint}`);
+      for (const b of blockers) console.log(`    · #${b.child}: ${b.codes.join(', ')}`);
+    } else {
+      console.log(`[epic-child-baton-traceability] Epic #${epicNumber}: no per-child evidence blockers — clear to close.`);
+    }
+    process.exit(0); // advisory-first: hint never fails the run
+    return;
+  }
+
   const { warnings } = auditEpics(scanMirror(dir));
   console.log(`[epic-child-baton-traceability] ADVISORY: ${warnings.length} bundling-drift warning(s).`);
   for (const w of warnings) console.log(`  ⚠ #${w.child ?? w.epic} [${w.code}] ${w.message}`);
@@ -95,4 +148,4 @@ function main() {
 
 if (require.main === module) main();
 
-module.exports = { auditEpics, parseMirrorTicket, scanMirror, isClosed };
+module.exports = { auditEpics, epicCloseHint, parseMirrorTicket, scanMirror, isClosed };

--- a/scripts/epic-child-baton-traceability.spec.js
+++ b/scripts/epic-child-baton-traceability.spec.js
@@ -4,7 +4,7 @@
 'use strict';
 
 const assert = require('assert');
-const { auditEpics, parseMirrorTicket, isClosed } = require('./epic-child-baton-traceability');
+const { auditEpics, epicCloseHint, parseMirrorTicket, isClosed } = require('./epic-child-baton-traceability');
 
 let passed = 0; let failed = 0;
 function test(name, fn) {
@@ -17,6 +17,9 @@ const child = (n, e, status, opts = {}) => ({
   number: n, file: `${n}.md`, type: 'task', status, refsEpic: e,
   hasCloseout: opts.closeout !== false, hasEvidence: opts.evidence !== false,
 });
+// alias — AC3 tests destructure a local `epic` from epicCloseHint()'s result, so the
+// factory is referenced as `epic0` inside those tests to avoid a TDZ shadow.
+const epic0 = epic;
 
 test('bundling drift: closed child of closed epic missing closeout+evidence → EB1+EB2', () => {
   const { warnings } = auditEpics([
@@ -83,6 +86,56 @@ test('regression: #2345 family (post-remediation) produces zero bundling warning
   const fam = [epic(2345, 'CLOSED')];
   for (const n of [2346, 2347, 2348, 2349, 2350]) fam.push(child(n, 2345, 'CLOSED'));
   assert.deepStrictEqual(auditEpics(fam).warnings, []);
+});
+
+// ── AC3 (#3800 Phase-1): Epic-close-time remediation hint ────────────────────
+test('AC3 epicCloseHint: names the un-evidenced children of the closing epic', () => {
+  const { epic, blockers, hint } = epicCloseHint([
+    epic0(700, 'CLOSED'),
+    child(701, 700, 'CLOSED', { closeout: false, evidence: false }),
+    child(702, 700, 'CLOSED', { evidence: false }),
+    child(703, 700, 'CLOSED'), // fully evidenced → not a blocker
+  ], 700);
+  assert.strictEqual(epic, 700);
+  assert.deepStrictEqual(blockers.map((b) => b.child), [701, 702]);
+  assert.deepStrictEqual(blockers[0].codes, ['EB1_child_missing_closeout', 'EB2_child_missing_evidence']);
+  assert.deepStrictEqual(blockers[1].codes, ['EB2_child_missing_evidence']);
+  assert.ok(/#701/.test(hint) && /#702/.test(hint), 'hint names the blocking children');
+  assert.ok(!/#703/.test(hint), 'fully-evidenced child is not named');
+  assert.ok(/do not bundle-close/i.test(hint), 'hint is actionable');
+});
+
+test('AC3 epicCloseHint: clean epic → null hint, no blockers (low false-positive)', () => {
+  const res = epicCloseHint([epic0(710, 'CLOSED'), child(711, 710, 'CLOSED')], 710);
+  assert.strictEqual(res.hint, null);
+  assert.deepStrictEqual(res.blockers, []);
+});
+
+test('AC3 epicCloseHint: open epic / non-epic / unknown id → null hint (never fires prematurely)', () => {
+  // open epic (not yet closing)
+  assert.strictEqual(epicCloseHint([epic0(720, 'OPEN'), child(721, 720, 'CLOSED', { closeout: false })], 720).hint, null);
+  // number belongs to a non-epic
+  assert.strictEqual(epicCloseHint([
+    { number: 730, file: '730.md', type: 'task', status: 'CLOSED', refsEpic: null },
+    child(731, 730, 'CLOSED', { closeout: false }),
+  ], 730).hint, null);
+  // unknown id
+  assert.strictEqual(epicCloseHint([epic0(740, 'CLOSED')], 999).hint, null);
+});
+
+test('AC3 epicCloseHint: open-child blocker (EB3) is surfaced in the close-time hint', () => {
+  const { blockers, hint } = epicCloseHint([epic0(750, 'CLOSED'), child(751, 750, 'OPEN')], 750);
+  assert.deepStrictEqual(blockers.map((b) => b.child), [751]);
+  assert.deepStrictEqual(blockers[0].codes, ['EB3_open_child_of_closed_epic']);
+  assert.ok(/#751/.test(hint));
+});
+
+test('AC3 epicCloseHint: scopes to the requested epic only (ignores other epics\' drift)', () => {
+  const res = epicCloseHint([
+    epic0(760, 'CLOSED'), child(761, 760, 'CLOSED'), // clean
+    epic0(770, 'CLOSED'), child(771, 770, 'CLOSED', { closeout: false }), // dirty, different epic
+  ], 760);
+  assert.strictEqual(res.hint, null, 'requested epic is clean; another epic\'s drift must not leak in');
 });
 
 test('wiring contract: exports the { auditEpics, scanMirror } interface governance-verify.js requires', () => {

--- a/wiki/work-log/ticket-3800/ac3-admin.md
+++ b/wiki/work-log/ticket-3800/ac3-admin.md
@@ -1,0 +1,30 @@
+---
+title: "#3800-AC3 Admin — merge execution"
+type: work-log
+role: ADMIN
+ticket: 3800
+ac: 3
+created: "2026-07-15"
+status: PENDING_MERGE
+---
+# #3800-AC3 — Admin baton
+
+## Merge plan
+- Branch `feat/3800-ac3-close-hint` (claim held: `claim/3800-ac3`).
+- PR body cites mirror path `wiki/work-log/tickets/3800.md` — NO `Closes #N` (mirror universe).
+- CI: presence-gate, validator-discipline, enforcement-wiring-audit, governance-verify,
+  state-store-merge-reconciler, secret-scan, baton-e2e, SKILL/instruction validators — must be green.
+- Squash-merge to UNPROTECTED `main`.
+
+## Autonomy-Decision: reversible
+Feature-branch push + PR + squash-merge to an UNPROTECTED `main` is reversible ⇒ completed
+autonomously per G8 (dogfooding the #3799 AC2 taxonomy). No carve-out: no protected/production merge,
+nothing irreversible, no security-weakening (additive advisory-only extension).
+
+## Steps (stamped on completion)
+- [ ] push branch
+- [ ] pr_create
+- [ ] ci_green
+- [ ] squash-merge
+- [ ] release claim/3800-ac3 (from non-merged detached worktree)
+- [ ] prune branch + worktree

--- a/wiki/work-log/ticket-3800/ac3-collaborator.md
+++ b/wiki/work-log/ticket-3800/ac3-collaborator.md
@@ -1,0 +1,41 @@
+---
+title: "#3800-AC3 Collaborator — Epic-close-time remediation hint (execution + evidence)"
+type: work-log
+role: COLLABORATOR
+ticket: 3800
+ac: 3
+created: "2026-07-15"
+status: VALIDATED
+---
+# #3800-AC3 — Collaborator execution
+
+## Change (reuse-first extension of the already-wired validator)
+`scripts/epic-child-baton-traceability.js`:
+- New pure `epicCloseHint(tickets, epicNumber)` → `{ epic, blockers:[{child, codes:[...]}], hint }`.
+  Reuses `auditEpics()`, filters to the requested epic, groups warnings by child, and emits an
+  actionable close-time hint naming the blocking children. Returns `hint:null` + `blockers:[]` when
+  the epic is clean OR is not an actually-closing Epic (unknown id / non-epic / open epic) — no noise.
+- New CLI mode `--epic <N>` prints the close-time hint for the Manager/Admin baton path
+  (advisory-first, exit 0). Default (no-flag) CLI behavior UNCHANGED.
+- Exported `epicCloseHint` for programmatic callers.
+
+`scripts/epic-child-baton-traceability.spec.js`: +6 AC3 cases (names the right children; clean→null;
+open/non-epic/unknown→null; EB3 open-child surfaced; scoped to requested epic only). Added an `epic0`
+alias to avoid a TDZ shadow where a test destructures a local `epic` from the result.
+
+`docs/howto/epic-child-baton-traceability.md`: new "Close-time remediation hint (AC3)" section.
+
+## Validation evidence
+- Unit: `node scripts/epic-child-baton-traceability.spec.js` → **14/14 passed** (8 pre-existing + 6 AC3).
+- CLI on tracked corpus: `--epic 3799` → "clear to close"; `--epic 3800` (open) → "clear to close";
+  default advisory → "0 bundling-drift warning(s)". **0 findings** (low-FP confirmed).
+- Enforcement: `enforcement-wiring-audit` → **25/25 enforced, 0 UNWIRED** (validator stays enforced;
+  extension, not a new file). `enforcement-telemetry --check` → exit 0, no regression.
+- Baseline: NOT updated — this is an EXTENSION (no new validator ⇒ count unchanged at 25). The
+  committed baseline file (`enforcedCount: 24`) is pre-existing #2275 debt (an increase to 25 is not a
+  regression, so `--check` passes); out of #3800 scope — left untouched.
+- Hermetic: `git archive feat/3800-ac3-close-hint | tar -x -C /tmp/ci` clean `.git`-less tree →
+  `epic-child-baton-traceability.spec` 14/14 + `governance-verify.spec` 7/7 green (post-commit run).
+- `governance-verify.spec.js` → 7/7 green (verdict-preserving).
+
+Autonomy-Decision: reversible (feature push + PR + squash-merge to unprotected main).

--- a/wiki/work-log/ticket-3800/ac3-consultant.md
+++ b/wiki/work-log/ticket-3800/ac3-consultant.md
@@ -1,0 +1,49 @@
+---
+title: "#3800-AC3 Consultant — independent critique"
+type: work-log
+role: CONSULTANT
+ticket: 3800
+ac: 3
+created: "2026-07-15"
+status: ACCEPT
+---
+# #3800-AC3 — Consultant critique
+
+## Verdict: ACCEPT — risk LOW
+
+### Does AC3 meet its criterion?
+Yes. AC3 requires "an actionable remediation hint at Epic-close time (Manager/Admin baton path)
+naming the un-evidenced children." `epicCloseHint()` + the `--epic <N>` CLI produce exactly that: a
+child-naming, actionable message ("give each its own CONSULTANT_CLOSEOUT + GitHub Evidence Block …
+do not bundle-close"), scoped to the specific Epic being closed.
+
+### Reuse-first / scope discipline
+The change reuses the validated `auditEpics()` predicate rather than reimplementing detection — the
+hint's false-positive profile is identical to the Phase-0 detector already shipped and consensus-
+ratified. No new validator was introduced, so the enforcement count is unchanged (25/25) and the
+baseline was correctly left untouched (a NEW validator would move it; an extension does not).
+
+### Low-false-positive (the standing hazard for this family)
+Verified by construction and by test: `epicCloseHint` returns `null` for a clean epic, an open epic,
+a non-epic id, and an unknown id; and scopes strictly to the requested epic (does not leak another
+epic's drift). On the tracked corpus it produces 0 findings. This satisfies the roadmap's low-FP rule
+— it keys off the structured `auditEpics` predicate, not keyword-matched prose.
+
+### Advisory boundary respected
+AC3 is a HINT, not a gate — the CLI always exits 0. Promotion to a blocking Epic-close gate remains
+AC4 (needs the shadow-FP metric + a fresh cross-family consensus per the Epic's hard gate). This
+change does not pre-empt that boundary.
+
+### Evidence integrity (C-G1): NONE at risk
+No fabricated tests, no manufactured scope — AC3 is a written, committed acceptance criterion on the
+OPEN Epic #3800. The pre-existing `1893.md` MC3 advisory and the ~640 untracked-corpus figure are
+correctly left as-is.
+
+### Verification reviewed
+14/14 unit green; hermetic clean-tree archive 14/14 + governance-verify 7/7; enforcement-wiring-audit
+25/25 enforced 0 unwired; telemetry --check exit 0. Cross-family panel PASS, receipt
+`8d1fb133a7c1d16d` (families meta[groq] + mistral — 2 distinct).
+
+## Recommendation
+Merge. AC3 is complete; parent #3800 stays OPEN for AC4 (shadow-FP promotion) and AC5 (optional
+historical backfill).

--- a/wiki/work-log/ticket-3800/ac3-manager-scope.md
+++ b/wiki/work-log/ticket-3800/ac3-manager-scope.md
@@ -1,0 +1,53 @@
+---
+title: "#3800-AC3 Manager scope — Epic-close-time remediation hint (reuse-first)"
+type: work-log
+role: MANAGER
+ticket: 3800
+ac: 3
+created: "2026-07-15"
+status: SCOPED
+---
+# #3800-AC3 — Manager scope
+
+## AC3 criterion (verbatim from committed 3800.md)
+> AC3: **Phase-1** — Emit an actionable remediation hint at Epic-close time (Manager/Admin baton
+> path) naming the un-evidenced children.
+
+## Disposition: reuse-first extension of the ALREADY-WIRED validator (no new validator, no baseline move)
+Phase-0 shipped `scripts/epic-child-baton-traceability.js` (`auditEpics()` core, EB1/EB2/EB3
+invariants) already wired into `governance-verify` (AC2, PR 12). AC3 is the close-time surface: when
+an Epic is being closed, the Manager/Admin baton path needs a single, actionable, epic-scoped hint
+that NAMES the specific un-evidenced children to remediate first — not the whole-corpus advisory dump.
+
+Implement as an **extension of the existing enforced validator** (reuse `auditEpics`), NOT a new
+script:
+1. New exported pure fn `epicCloseHint(tickets, epicNumber)` → `{ epic, blockers:[{child,codes}], hint }`.
+   Reuses `auditEpics()` and filters to the one epic being closed. Returns `hint:null` +
+   `blockers:[]` when the epic is clean / not-a-closing-epic (NO noise — low-FP by construction, same
+   predicate as the validated Phase-0 detector).
+2. New CLI mode `--epic <N>` prints the close-time hint (exit 0, advisory-first) for the Admin/Manager
+   baton path to invoke at close-time. Default (no flag) CLI behavior UNCHANGED.
+3. New sibling-spec cases (`epic-child-baton-traceability.spec.js`) covering: hint names the right
+   children; clean epic → null hint; non-epic / open-epic → null; CLI `--epic` mode.
+
+## Acceptance gate for this AC
+1. `epicCloseHint` implemented + exported; deterministic, pure, reuses `auditEpics`.
+2. `--epic <N>` CLI mode prints an actionable child-naming hint (advisory, exit 0).
+3. Sibling spec extended + green (hermetic clean-tree archive run).
+4. Validator stays ENFORCED (enforcement-wiring-audit: still enforced, 0 unwired). Because this is an
+   EXTENSION of an existing validator (no NEW validator file), the enforcement baseline STAYS 24 —
+   do NOT run `--update-baseline` (telemetry must show unchanged count).
+5. Cross-family ≥2-distinct-family PASS receipt; cited.
+6. Flip AC3 `[ ]`→`[x]` on committed 3800.md; parent #3800 stays OPEN (AC4/AC5 remain).
+7. Full baton artifacts under `wiki/work-log/ticket-3800/`.
+
+## Constraints
+- Touch ONLY #3800 files: `scripts/epic-child-baton-traceability.js` (+ its `.spec.js`),
+  `docs/howto/epic-child-baton-traceability.md` (append AC3 note), `wiki/work-log/tickets/3800.md`,
+  `wiki/work-log/ticket-3800/*`. Do NOT touch other validators.
+- Advisory-first, LOW-FALSE-POSITIVE: emit a hint ONLY for a closing epic that has real
+  un-evidenced closed children (reuse the validated predicate) — never keyword-scan prose.
+- Reversible (feature push + PR + squash-merge to UNPROTECTED main) ⇒ autonomous completion (G8).
+  Autonomy-Decision: reversible.
+- AC3 is a close-time HINT, NOT a blocking gate — promotion to blocking is AC4 (needs shadow-FP
+  metric + consensus per the Epic's hard gate). AC3 stays advisory.

--- a/wiki/work-log/tickets/3800.md
+++ b/wiki/work-log/tickets/3800.md
@@ -58,7 +58,7 @@ Epic close that bundles un-evidenced children. No silent bulk closure. G1 non-ne
 - [x] AC1: Advisory detector + spec shipped and green (Phase-0, reuse the `accountable-team-verify` advisory pattern).
 - [x] AC2: Wired the detector into `governance-verify.js` as an advisory section (default-on, non-blocking), mirroring the ownership advisory (#2345 AC3). Kill-switch `EPIC_CHILD_BATON_ADVISORY=0`.
 - [x] AC3: **Phase-1** — Emit an actionable remediation hint at Epic-close time (Manager/Admin baton path) naming the un-evidenced children.
-      **DONE 2026-07-15** (branch `feat/3800-ac3-close-hint`, PR 24): reuse-first EXTENSION of the
+      **DONE 2026-07-15** (branch `feat/3800-ac3-close-hint`, PR 25): reuse-first EXTENSION of the
       already-wired detector — new pure `epicCloseHint(tickets, epicNumber)` reuses `auditEpics()` to
       return `{ epic, blockers:[{child, codes}], hint }` naming the specific un-evidenced/open children
       of the Epic being closed; `hint` is `null` when the Epic is clean or not an actually-closing Epic

--- a/wiki/work-log/tickets/3800.md
+++ b/wiki/work-log/tickets/3800.md
@@ -57,7 +57,20 @@ Epic close that bundles un-evidenced children. No silent bulk closure. G1 non-ne
 
 - [x] AC1: Advisory detector + spec shipped and green (Phase-0, reuse the `accountable-team-verify` advisory pattern).
 - [x] AC2: Wired the detector into `governance-verify.js` as an advisory section (default-on, non-blocking), mirroring the ownership advisory (#2345 AC3). Kill-switch `EPIC_CHILD_BATON_ADVISORY=0`.
-- [ ] AC3: **Phase-1** — Emit an actionable remediation hint at Epic-close time (Manager/Admin baton path) naming the un-evidenced children.
+- [x] AC3: **Phase-1** — Emit an actionable remediation hint at Epic-close time (Manager/Admin baton path) naming the un-evidenced children.
+      **DONE 2026-07-15** (branch `feat/3800-ac3-close-hint`, PR 24): reuse-first EXTENSION of the
+      already-wired detector — new pure `epicCloseHint(tickets, epicNumber)` reuses `auditEpics()` to
+      return `{ epic, blockers:[{child, codes}], hint }` naming the specific un-evidenced/open children
+      of the Epic being closed; `hint` is `null` when the Epic is clean or not an actually-closing Epic
+      (low-FP by construction — same validated predicate). New CLI mode
+      `node scripts/epic-child-baton-traceability.js --epic <N>` prints the close-time hint for the
+      Manager/Admin baton path (advisory-first, exit 0); default CLI behavior unchanged. Sibling spec
+      +6 AC3 cases (14/14 green); hermetic clean-tree archive green. NO new validator (extension of an
+      enforced one) ⇒ enforcement count unchanged (25/25 enforced, 0 unwired), baseline untouched.
+      0 findings on the tracked corpus. Docs: `docs/howto/epic-child-baton-traceability.md`
+      (close-time hint section). Cross-family consensus PASS, receipt `8d1fb133a7c1d16d`
+      (groq[meta] + mistral). Artifacts: `wiki/work-log/ticket-3800/ac3-*.md`.
+      (Parent stays OPEN — AC4/AC5 remain.)
 - [ ] AC4: **Phase-1** — Shadow-period metric (false-positive rate over the corpus); promote EB1/EB2/EB3 from advisory to a hard Epic-close gate only at < 2% FP.
 - [ ] AC5: **Phase-1** — (Scoped, optional) historical backfill plan for the ~640 pre-existing instances — deterministic, additive, dry-run default; NOT required to close the guard, tracked as a separate child.
 - [x] AC6: Docs — `docs/howto/epic-child-baton-traceability.md` note documenting the per-child evidence requirement + run/remediation.


### PR DESCRIPTION
Phase-1 AC3 of the OPEN self-anneal Epic #3800 (per-child baton traceability). **Reuse-first extension** of the already-wired `epic-child-baton-traceability` detector — no new validator.

## What
- New pure `epicCloseHint(tickets, epicNumber)` reuses `auditEpics()` to return `{ epic, blockers:[{child, codes}], hint }` naming the un-evidenced/open children of the Epic being closed. `hint` is `null` when the Epic is clean or not an actually-closing Epic (low-FP by construction — same validated predicate).
- New CLI mode `node scripts/epic-child-baton-traceability.js --epic <N>` prints the close-time hint for the Manager/Admin baton path (advisory-first, exit 0). Default CLI behavior unchanged.
- Docs: `docs/howto/epic-child-baton-traceability.md` close-time-hint section.

## Evidence
- Spec: 14/14 (8 pre-existing + 6 AC3); hermetic clean-tree archive → 14/14 + governance-verify 7/7.
- Enforcement: 25/25 enforced, 0 unwired; telemetry --check exit 0. No new validator ⇒ count/baseline unchanged.
- 0 findings on tracked corpus. Cross-family consensus PASS, receipt `8d1fb133a7c1d16d` (meta + mistral).

## Mirror-mode
No live GitHub issue (mirror universe caps at real issue 5). Mirror path: `wiki/work-log/tickets/3800.md` (AC3 checkbox flipped; parent stays OPEN for AC4/AC5). Baton artifacts under `wiki/work-log/ticket-3800/`.

**Autonomy-Decision: reversible** — additive advisory-only extension; feature branch + squash-merge to unprotected main ⇒ completed autonomously (G8).