### PR TITLE
feat(#3809): track goal_lens hook + free-fleet-first goal-lens clause

### DIFF
--- a/hooks/scripts/goal_lens.py
+++ b/hooks/scripts/goal_lens.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""UserPromptSubmit hook: inject G1-G10 decision lens + operator-autonomy context.
+
+Per Epic #1113 AC5 (extends D-009 #1123 hybrid): full tier ladder
+B / B+ / B++ / B+++ / B++++ resolved from goal-tier-state.json + role.
+Tier ladder strings + resolver live in goal_tier_resolver.py.
+Epic #3391: also injects the cross-cutting operator-autonomy principle (Option B).
+"""
+import json
+import os
+import re
+import sys
+
+from goal_tier_resolver import (
+    read_tier_from_state, resolve_tier, context_for_tier,
+)
+
+GOALS = (
+    "G1 Governance > G2 Quality > G3 Zero Cost > G4 Privacy & Security > "
+    "G5 Portability > G6 Resilience > G7 Throughput > "
+    "G8 Observability > G9 Interoperability > G10 Maintainability"
+)
+
+# Epic #3391 (Option B): operator autonomy is a cross-cutting, always-on PRINCIPLE
+# (not a ranked goal). Injected alongside the priority sentence on every prompt.
+AUTONOMY = (
+    "Operator autonomy (always-on principle): resolve reversible/low-risk work autonomously "
+    "(free cross-model panel, never a bare client prompt); reach the human only at the 4 retained "
+    "carve-outs (design/UAT/irreversible/security-weakening); never override C-G1 or C-G4; log the "
+    "autonomy-vs-escalate decision (G8)."
+)
+
+# Operator directive 2026-07-15: make G3's free-fleet preference EXPLICIT on every
+# prompt, kept STRICTLY SUBORDINATE to G1 Governance and G2 Quality — never trade
+# correctness or governance for cost. Advisory nudge (injection), not a hard gate.
+FREE_FIRST = (
+    "Free-fleet-first (G3, subordinate to G1/G2): prefer free fleet resources for every "
+    "action where one applies — before any paid inference, route to free fleet first "
+    "(local Ollama / OpenRouter-free / free cross-family panel); escalate to paid only when "
+    "free is unavailable, unreliable, or would compromise G1 Governance or G2 Quality; "
+    "log the free-first decision (G8)."
+)
+
+ANNEAL_RE = re.compile(
+    r"\b(anneal|self-anneal|recurr|mid-flight|tier-2|repeat failure|pattern)\b",
+    re.IGNORECASE,
+)
+
+DECISION_RE = re.compile(
+    r"\b(decide|decision|choose|tradeoff|priority|prioritize|rank|route|"
+    r"policy|architecture|design|should we|which option|compare)\b",
+    re.IGNORECASE,
+)
+
+# Epic #1436 D-1436-01: in-session Tier-2 worker awareness.
+# When prompts mention recurrence/anneal/repeat-failure patterns, surface
+# concise guidance reminding the worker that a Tier-2 anneal event should
+# be emitted proactively, without waiting for the nightly cron.
+RECURRENCE_RE = re.compile(
+    r"\b(anneal|self-anneal|tier-?2|mid-?flight|"
+    r"recurr(?:ence|ent|ing)?|repeat(?:ed)?\s+failure|"
+    r"happened\s+again|same\s+error\s+twice|drift\s+pattern)\b",
+    re.IGNORECASE,
+)
+RECURRENCE_GUIDANCE = (
+    "Tier-2 mid-flight awareness (#1436): if this is a recurring pattern "
+    "(≥2 in 7d at severity ≥ medium), emit `event:goal-failure-escalation` "
+    "or file a Tier-2 anneal ticket NOW — do not wait for the nightly cron. "
+    "See `instructions/workflow-resilience.instructions.md` Tier-2 model "
+    "and `feedback_anneal_emission_during_implementation.md`."
+)
+
+
+def get_active_role(payload: dict) -> str:
+    """Resolve active role from payload or env (lowercase, stripped)."""
+    role = str(payload.get("role", "")).lower().strip()
+    if role:
+        return role
+    return os.environ.get("MEGINGJORD_ROLE", "").lower().strip()
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        return 0
+
+    prompt = str(payload.get("prompt", ""))
+    if not prompt:
+        return 0
+
+    base = f"Goal lens: {GOALS}. {AUTONOMY} {FREE_FIRST}"
+    if DECISION_RE.search(prompt):
+        base += " Decision check: justify any lower-priority override with explicit evidence."
+    if ANNEAL_RE.search(prompt):
+        base += (
+            " Anneal awareness: if a recurrence pattern is observed mid-flight, "
+            "surface or file the Tier-2 signal now instead of waiting for the nightly cron."
+        )
+
+    if RECURRENCE_RE.search(prompt):
+        base += " " + RECURRENCE_GUIDANCE
+
+    role = get_active_role(payload)
+    tier = resolve_tier(read_tier_from_state(), role)
+    base += context_for_tier(tier)
+
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "UserPromptSubmit",
+            "additionalContext": base,
+            "goalLensTier": tier,
+        }
+    }))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hooks/scripts/goal_tier_resolver.py
+++ b/hooks/scripts/goal_tier_resolver.py
@@ -1,0 +1,95 @@
+"""Goal-tier resolver for goal_lens.py — Epic #1113 AC5.
+
+Reads ~/.megingjord/goal-tier-state.json (written by actuator-engine.js A1)
+and resolves the effective tier for the current session, combining:
+  - state-derived tier (B / B+ / B++ / B+++ / B++++) from GHS thresholds
+  - role-minimum (Consultant role floor at B+ per D-009 #1123 hybrid)
+#3342: stale GHS telemetry decays to baseline B (no false elevation).
+"""
+import datetime
+import json
+import os
+import pathlib
+
+TIER_STATE_PATH = pathlib.Path.home() / ".megingjord" / "goal-tier-state.json"
+TIER_ORDER = ["B", "B+", "B++", "B+++", "B++++"]
+GHS_FRESHNESS_SECONDS = int(os.environ.get("GHS_FRESHNESS_SECONDS", str(7 * 24 * 3600)))
+
+DEFINITIONS_TIER_B_PLUS = (
+    "Goal definitions: "
+    "G1 Governance: policy, role, provenance, ticket controls non-negotiable. "
+    "G2 Quality: maximize correctness and engineering value. "
+    "G3 Zero Cost: prefer local/fleet/free lanes before paid providers. "
+    "G4 Privacy: keep sensitive context local unless explicit override. "
+    "G5 Portability: avoid user-specific coupling; settings-driven. "
+    "G6 Resilience: graceful degradation; fallback paths. "
+    "G7 Throughput: acceptable speed after higher-priority goals met. "
+    "G8 Observability: decisions visible, auditable, attributable. "
+    "G9 Interoperability: preserve compatibility across runtimes."
+)
+TIER_B_PLUS_PLUS_NOTE = (
+    "Tier B++ (#1113): recent governance violations elevated. Cite "
+    "evidence for any G3-or-lower override; consultant pre-check advised."
+)
+TIER_B_PLUS_PLUS_PLUS_NOTE = (
+    "Tier B+++ (#1113): per-role goal reminders active. Manager: scope. "
+    "Collaborator: validate. Admin: gate. Consultant: critique independently."
+)
+TIER_B_QUAD_PLUS_NOTE = (
+    "Tier B++++ (#1113): consultant pre-action review FORCED on this work. "
+    "Post a consultant_pre_action_check artifact before continuing."
+)
+
+
+def ghs_is_stale(data, now=None):
+    """#3342: True when GHS telemetry is absent or older than the freshness window."""
+    ref = now or datetime.datetime.now(datetime.timezone.utc)
+    newest = None
+    for entry in (data or {}).get("ghs_history") or []:
+        try:
+            dt = datetime.datetime.fromisoformat(
+                str((entry or {}).get("ts")).replace("Z", "+00:00"))
+        except (ValueError, TypeError):
+            continue
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=datetime.timezone.utc)
+        if newest is None or dt > newest:
+            newest = dt
+    return newest is None or (ref - newest).total_seconds() > GHS_FRESHNESS_SECONDS
+
+
+def read_tier_from_state(state_path=TIER_STATE_PATH) -> str:
+    """Read tier; default B. #3342: decay a stale elevation to B (GHS_DECAY_DISABLED=1 to opt out)."""
+    try:
+        data = json.loads(pathlib.Path(state_path).read_text(encoding="utf8"))
+        tier = (((data or {}).get("actuators") or {}).get("A1") or {}).get("tier")
+        if isinstance(tier, str) and tier in TIER_ORDER:
+            if (tier != "B" and os.environ.get("GHS_DECAY_DISABLED") != "1"
+                    and ghs_is_stale(data)):
+                return "B"
+            return tier
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        pass
+    return "B"
+
+
+def resolve_tier(state_tier: str, role: str) -> str:
+    """Resolve effective tier: max(state, role==consultant ? B+ : B)."""
+    role_minimum = "B+" if role == "consultant" else "B"
+    state_idx = TIER_ORDER.index(state_tier) if state_tier in TIER_ORDER else 0
+    role_idx = TIER_ORDER.index(role_minimum)
+    return TIER_ORDER[max(state_idx, role_idx)]
+
+
+def context_for_tier(tier: str) -> str:
+    """Return additional context string for tiers >= B+ (empty for B)."""
+    parts = []
+    if TIER_ORDER.index(tier) >= TIER_ORDER.index("B+"):
+        parts.append(DEFINITIONS_TIER_B_PLUS)
+    if TIER_ORDER.index(tier) >= TIER_ORDER.index("B++"):
+        parts.append(TIER_B_PLUS_PLUS_NOTE)
+    if TIER_ORDER.index(tier) >= TIER_ORDER.index("B+++"):
+        parts.append(TIER_B_PLUS_PLUS_PLUS_NOTE)
+    if TIER_ORDER.index(tier) >= TIER_ORDER.index("B++++"):
+        parts.append(TIER_B_QUAD_PLUS_NOTE)
+    return " " + " ".join(parts) if parts else ""

--- a/wiki/work-log/ticket-3809/collaborator-validation.md
+++ b/wiki/work-log/ticket-3809/collaborator-validation.md
@@ -1,0 +1,36 @@
+# Ticket #3809 — Collaborator Validation 🔧
+
+**Baton received from:** Manager (scope: land free-fleet-first clause + track goal_lens hook)
+
+## Files changed
+
+- `hooks/scripts/goal_lens.py` — **new tracked file** (was untracked live-harness state).
+  Added `FREE_FIRST` constant + appended it to the injected `base` string after `AUTONOMY`.
+- `hooks/scripts/goal_tier_resolver.py` — **new tracked file** (goal_lens's sole internal
+  import; unchanged content, tracked so the hook resolves on a fresh install).
+- `wiki/work-log/ticket-3809/*` — baton artifacts.
+
+## The clause (subordinate to G1/G2 by construction)
+
+```
+Free-fleet-first (G3, subordinate to G1/G2): prefer free fleet resources for every action
+where one applies — before any paid inference, route to free fleet first (local Ollama /
+OpenRouter-free / free cross-family panel); escalate to paid only when free is unavailable,
+unreliable, or would compromise G1 Governance or G2 Quality; log the free-first decision (G8).
+```
+
+## Validation evidence
+
+| AC | Check | Result |
+|----|-------|--------|
+| AC1 | Clause present + states subordination to G1/G2 | PASS |
+| AC2 | `GOALS` ordering string unchanged (`G1 > G2 > G3 Zero Cost > ...`) | PASS |
+| AC3 | Imports resolve with isolated empty `HOME` (no `goal-tier-state.json`) → graceful default tier | PASS (clean stderr) |
+| AC4 | `python3 goal_lens.py` on sample payload → valid JSON, `additionalContext` + `goalLensTier` keys intact | PASS |
+| AC5 | Required CI workflows green | see admin-handoff (run on PR) |
+| AC6 | Cross-family $0 review consensus receipt | see consultant-closeout |
+
+Command (reproducible):
+`HOME=/tmp/empty python3 hooks/scripts/goal_lens.py <<< '{"prompt":"optimize the fleet"}'`
+
+**Baton → Admin**

--- a/wiki/work-log/ticket-3809/manager-scope.md
+++ b/wiki/work-log/ticket-3809/manager-scope.md
@@ -1,0 +1,57 @@
+# Ticket #3809 — Manager Scope 🎯
+
+**Title:** Land goal-lens free-fleet-first clause into tracked hooks/scripts (durability + operator directive)
+**Type:** task · **Area:** hooks · **Priority:** P2 · **Points:** 2
+**Parent:** operator directive 2026-07-15 (free-fleet-first as always-on session goal); relates to Epic #3391 (operator-autonomy injection)
+
+## Objective
+
+Make "prefer free fleet resources wherever one applies" an explicit, always-on part of
+the per-prompt goal lens — **strictly subordinate to G1 Governance and G2 Quality** — and
+make that behavior **durable and reviewable** by committing the hook to the tracked tree.
+
+Operator chose the lightweight injection route (strengthen the `UserPromptSubmit` goal-lens
+hook) over a hard enforcement gate. Manager research found the real gap: `goal_lens.py` — the
+hook that already injects the goal lens on every prompt — and its import `goal_tier_resolver.py`
+are **untracked in `origin/main`** (they run only as live-harness state). So the durable route
+necessarily lands these two files into tracked `hooks/scripts/`, carrying the new clause.
+
+## Scope (in)
+
+1. Add a `FREE_FIRST` clause to `hooks/scripts/goal_lens.py`, appended after the existing
+   `AUTONOMY` line, explicitly marked subordinate to G1/G2.
+2. Commit `hooks/scripts/goal_lens.py` + `hooks/scripts/goal_tier_resolver.py` (its sole
+   internal import) into the tracked tree, alongside the 4 already-tracked sibling hooks.
+
+## Scope (out — logged as follow-up, not this ticket)
+
+- The other ~8 untracked live hooks (`manager_ticket_gate.py`, `userprompt_gate.py`,
+  `hamr_activation_check.py`, `canonical_main_wip_check.py`, `runtime_session_register.py`,
+  `prune_file_history.py`, `commit_ticket_gate.py`, `stuck_state_gate.py`) have the same
+  tracking gap → separate follow-up ticket. Do NOT expand this ticket to cover them.
+- No hard enforcement (PreToolUse/Stop) gate. Injection only — advisory nudge.
+- No change to goal ranking; G3 stays #3, below G1/G2.
+
+## Acceptance criteria
+
+- [ ] AC1: `goal_lens.py` emits the free-first clause in `additionalContext`, and the clause
+      text explicitly states subordination to G1 Governance and G2 Quality.
+- [ ] AC2: Clause does NOT alter the `GOALS` ordering string (G3 stays rank 3).
+- [ ] AC3: `goal_lens.py` + `goal_tier_resolver.py` are tracked in the merge to `origin/main`;
+      hook imports resolve with no runtime `goal-tier-state.json` present (graceful default).
+- [ ] AC4: `python3 goal_lens.py` on a sample payload returns valid JSON (schema unchanged:
+      `hookSpecificOutput.additionalContext` + `goalLensTier`).
+- [ ] AC5: All required CI workflows green on the PR (validate-pr, governance-verify,
+      validator-discipline, enforcement-wiring-audit, global-governance-presence).
+- [ ] AC6: Cross-family $0 review consensus receipt recorded (advisory, per G3/no-cost).
+
+## Constraints / gates
+
+- G1 > G2 > G3: the clause must never imply trading correctness/governance for cost.
+- Branch off `origin/main` only (not the parked feat/3026 drift checkout). Branch:
+  `feat/3809-goal-lens-free-first`. Commits reference `#3809`. PR body `Closes #3809`.
+- Read-only-mirror rule: no direct commit to local main; land via PR (sanctioned flow).
+- DoD per manager-ticket-lifecycle: ACs checked, CI green, PR merged Closes #3809,
+  Consultant CLOSEOUT posted, mirror status → done.
+
+**Baton → Collaborator**


### PR DESCRIPTION
## Summary
Makes "prefer free fleet resources wherever one applies" an explicit, always-on part of the per-prompt goal lens — **strictly subordinate to G1 Governance and G2 Quality** — and makes it durable by committing the hook that injects it.

Manager research (mirror ticket 3809) found the real gap: `goal_lens.py` (injects the goal lens on every prompt) and its import `goal_tier_resolver.py` were **untracked in origin/main** — running only as live-harness state. This lands both into tracked `hooks/scripts/` alongside the 4 already-tracked sibling hooks, carrying the new `FREE_FIRST` clause.

## Guarantees
- `GOALS` ordering string UNCHANGED — G3 Zero Cost stays rank 3, below G1/G2.
- Injection-only advisory nudge; no hard enforcement gate.
- Hook JSON schema unchanged (additionalContext + goalLensTier).
- Imports resolve with no runtime goal-tier-state.json (graceful default).

## Validation
- CI local: governance-verify PASS, validator-discipline OK, enforcement-wiring 28/28, global-governance-presence PASS, py_compile OK.
- Cross-family $0 consensus: **PASS** (receipt bf25c035c451e7f2; families meta/groq + mistral).

## Scope out (follow-up)
~8 other untracked live hooks share the tracking gap → separate ticket; not expanded here.

Closes #3809