### PR TITLE
docs(#3810): Manager scope — Stop-hook session-attributable uncommitted gate

### DIFF
--- a/wiki/work-log/ticket-3810/manager-scope.md
+++ b/wiki/work-log/ticket-3810/manager-scope.md
@@ -1,0 +1,84 @@
+# Ticket #3810 — Manager Scope 🎯
+
+**Title:** Stop hook: gate uncommitted-block on session-attributable code, not standing baseline drift
+**Type:** bug · **Area:** hooks · **Priority:** P2 · **Points:** 3
+**Parent:** operator directive 2026-07-15 · relates: #2005 (same bug class, detect_session_signals), #3054 (baseline_drift_override), #3801 (baseline capture)
+
+## Problem (observed)
+
+The `Stop` hook (`hooks/scripts/stop_reminder.py`) false-positive-blocks session end with
+`"Stop blocked: uncommitted changes; Admin baton incomplete."` whenever the cwd is the parked
+canonical checkout (`feat/3026`), which carries **standing multi-ticket baseline drift** (~40
+modified tracked + ~724 untracked files) that is intentionally uncommitted and documented as
+"capture-as-baseline, NEVER discard" (#3801, re-park pending).
+
+### Root cause (traced)
+
+1. `git_checks.detect_uncommitted_changes(cwd)` runs a **raw `git status --porcelain`** → returns
+   the entire standing drift set.
+2. `stop_checks.check_uncommitted(uncommitted, roles)` blocks whenever any of those files match
+   `CODE_UNCOMMITTED_EXTS = (.sh,.js,.py,.ts,.json,.md)` **once `roles['collaborator']` is True** —
+   with **no attribution** to whether the current session authored them.
+3. Asymmetry: `check_admin_ops` already honors a `baseline_drift_override` (#3054), but
+   `check_uncommitted` honors **no** such exception and has **no** session-delta awareness.
+4. There is **no SessionStart baseline snapshot** of the uncommitted set anywhere
+   (`governance_state.py` / `runtime_session_register.py` do not capture one).
+
+This is the **same disease** already cured for `detect_session_signals` under #2005 ("Gap 2":
+don't fire in every new session after a code-changing merge) — the uncommitted path never got
+the equivalent session-scoping.
+
+## Objective
+
+Make the Stop uncommitted-block fire only on **session-attributable** uncommitted code — code the
+current session left uncommitted — never on pre-existing baseline drift present at SessionStart.
+Preserve the gate's real purpose (a session that writes code and forgets to commit STILL blocks).
+
+## Recommended approach (Collaborator may refine; ratify via cross-family review)
+
+**Primary — SessionStart baseline-delta (automatic, deterministic):**
+- At SessionStart, snapshot the set of uncommitted paths (`git status --porcelain`) into
+  `governance_state` (e.g. `baseline_uncommitted: [...]` or a stable hash+list). Reuse the existing
+  `runtime_session_register.py` SessionStart hook + `governance_state.ensure_state/save_state`.
+- At Stop, `check_uncommitted` blocks only on the **delta**: uncommitted code files NOT in the
+  SessionStart baseline. Reset the baseline on branch change (reuse `reset_on_branch_change`).
+
+**Complementary — override parity (#3054):** honor `baseline_drift_override` in `check_uncommitted`
+too, so an explicit operator/labelled marker also suppresses the block (parity with check_admin_ops).
+
+**Fail-safe direction:** if the baseline snapshot is missing/unreadable, fall back to the LEGACY
+behavior (block) — never fail-open in a way that hides a genuine session gap. The SessionStart hook
+must therefore write the snapshot reliably; document the missing-snapshot fallback explicitly.
+
+## Acceptance criteria
+
+- [ ] AC1: With a SessionStart baseline equal to current standing drift, Stop does NOT block on
+      those pre-existing files (the reported false positive is gone).
+- [ ] AC2: A NEW uncommitted code file created after SessionStart (not in baseline) STILL triggers
+      the block — no weakening of the real Admin gate.
+- [ ] AC3: `baseline_drift_override` honored by `check_uncommitted` (parity with `check_admin_ops`).
+- [ ] AC4: SessionStart records the baseline set deterministically into `governance_state`;
+      branch change resets it. Missing snapshot → legacy block (fail-safe), documented.
+- [ ] AC5: Sibling spec + `inventory/harness-self-test-registry.json` entry (#1893 discipline);
+      unit tests cover AC1/AC2/AC3/AC4; `py_compile` clean.
+- [ ] AC6: All required CI green on the PR; cross-family $0 consensus PASS (receipt recorded).
+- [ ] AC7: No change to unrelated Stop conditions (client-arbitration #3749, internal-conflict,
+      admin-ops, wiki-pending); the other tracked hooks' behavior otherwise unchanged.
+
+## Scope (out — do NOT do here)
+
+- Re-parking / cleaning the actual `feat/3026` baseline drift — that is the separate #3801 re-park
+  item. This ticket only fixes the GATE's false positive, not the drift itself.
+- No change to `check_admin_ops` semantics beyond the override-parity reuse.
+- No cross-harness propagation.
+
+## Constraints / gates
+
+- G1 > G2 > G3. Governance gate must not fail-open. Branch `feat/3810-stop-session-attributable`
+  off `origin/main`; commits reference `#3810`; PR `Closes #3810`. Read-only-mirror: land via PR.
+- Files: `wiki/` is gitignored → `git add -f` baton artifacts. Commit with `#3810` in the `-m`
+  text (PreToolUse guard scans command text). Poll `gh pr checks --watch` before merge.
+- DoD: all ACs checked, CI green, PR merged Closes #3810, Consultant CLOSEOUT posted, mirror
+  status → done, worktree/branch cleaned.
+
+**Baton → Collaborator** (next session)

--- a/wiki/work-log/tickets/3810.md
+++ b/wiki/work-log/tickets/3810.md
@@ -1,0 +1,45 @@
+---
+title: "#3810 Stop hook: gate uncommitted-block on session-attributable code, not baseline drift"
+type: work-log
+content_trust_score: 0.9
+created: "2026-07-15"
+updated: "2026-07-15"
+tags: [issue, wiki-b, hooks, stop-hook, baseline-drift, false-positive]
+related: [[ticket-3809-goal-lens-free-first-tracked]]
+status: OPEN
+source_path: "github:issue/3810"
+generated_by_run: local
+---
+# #3810 — Stop hook: session-attributable uncommitted gate (fix baseline-drift false positive)
+
+> **Source**: github:issue/3810 | **state: OPEN** | **Labels**: type:bug, priority:P2, area:hooks, status:ready, role:collaborator, accountable-team:claude-code
+> Operator directive 2026-07-15. Relates: #2005 (same bug class), #3054 (baseline_drift_override), #3801 (baseline capture).
+
+## Body
+
+The `Stop` hook false-positive-blocks session end (`"Stop blocked: uncommitted changes; Admin
+baton incomplete."`) on the parked `feat/3026` canonical checkout, whose standing multi-ticket
+baseline drift (~40 modified + ~724 untracked) is intentionally uncommitted (#3801, re-park pending).
+
+Root cause: `check_uncommitted` blocks on ANY uncommitted code file once `roles['collaborator']`
+is True, with no attribution to whether THIS session authored it, and no SessionStart baseline
+snapshot exists. Same disease already cured for `detect_session_signals` under #2005.
+
+Fix: block only on **session-attributable** uncommitted code via a SessionStart baseline-delta
+snapshot in `governance_state`, plus `baseline_drift_override` parity in `check_uncommitted`;
+fail-safe to legacy block when snapshot missing. Full scope + 7 ACs in
+`wiki/work-log/ticket-3810/manager-scope.md`.
+
+## Acceptance criteria
+- [ ] AC1 baseline == standing drift → Stop does NOT block on pre-existing files
+- [ ] AC2 new post-SessionStart uncommitted code file → STILL blocks (no weakening)
+- [ ] AC3 baseline_drift_override honored by check_uncommitted (parity with check_admin_ops #3054)
+- [ ] AC4 SessionStart records baseline into governance_state; branch-change resets; missing→legacy block
+- [ ] AC5 sibling spec + harness-self-test-registry entry (#1893); unit tests AC1-AC4; py_compile clean
+- [ ] AC6 required CI green; cross-family $0 consensus PASS (receipt recorded)
+- [ ] AC7 no change to unrelated Stop conditions (client-arbitration/internal-conflict/admin-ops/wiki)
+
+Signed-by: claude-code
+Team&Model: claude-code:claude-opus-4-8
+Role: manager
+verification-timestamp: 2026-07-15T00:00:00Z


### PR DESCRIPTION
Manager-phase baton artifact for #3810 (bug).

Files the mirror ticket + full scope (7 ACs) for the Stop-hook false-positive fix: the Stop hook blocks session end on the parked feat/3026 checkout's standing baseline drift because `check_uncommitted` has no session attribution and there is no SessionStart baseline snapshot (same bug class as #2005, already cured for `detect_session_signals`).

**No code change in this PR** — Collaborator implementation lands next session.

Refs #3810