### PR TITLE
feat(#3810): Stop hook — session-attributable uncommitted gate

### DIFF
--- a/hooks/scripts/session_baseline.py
+++ b/hooks/scripts/session_baseline.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Session-attributable uncommitted-baseline helpers (#3810).
+
+The Stop hook's uncommitted-code gate (`stop_checks.check_uncommitted`) used to block on ANY
+uncommitted code file once `roles['collaborator']` was True, with no attribution to whether the
+CURRENT session authored the file. On the parked `feat/3026` canonical checkout — which carries
+standing multi-ticket baseline drift (~40 modified + ~724 untracked, intentionally uncommitted per
+#3801) — that produced a permanent false-positive "Stop blocked: uncommitted changes" (same disease
+already cured for `detect_session_signals` under #2005).
+
+This module makes the gate fire only on **session-attributable** uncommitted code: code NOT present
+in the baseline snapshot taken at SessionStart. It is pure/stdlib-only (no dependency on the other
+hook modules) so it is unit-testable in isolation and safe to import from both the SessionStart
+(`session_context.py`) and Stop (`stop_checks.py` via `stop_reminder.py`) paths.
+
+Design (manager scope #3810):
+  * SessionStart snapshots `git status --porcelain` paths + the branch into `governance_state`
+    (`state["baseline_uncommitted"] = {"branch": <branch>, "paths": [...]}`).
+  * Stop blocks only on the DELTA vs that baseline (`attributable_delta`).
+  * Branch change resets the baseline implicitly: `resolve_baseline` returns None when the stored
+    branch != the current branch, so a stale snapshot is never trusted (fail-safe, not fail-open).
+  * Override parity with `check_admin_ops` (#3054): an explicit `baseline_drift_override` /
+    `merge_evidence_override` in admin_ops suppresses the block.
+
+FAIL-SAFE DIRECTION (never fail-open): whenever the baseline cannot be resolved — missing,
+malformed, unreadable, or captured on a different branch — the gate falls back to LEGACY behavior
+(evaluate the full uncommitted set), so a genuine session gap is never hidden. AC2 is preserved: a
+NEW post-SessionStart uncommitted code file is not in the baseline, lands in the delta, and STILL
+blocks.
+"""
+from __future__ import annotations
+
+import subprocess
+from typing import Iterable, Optional
+
+# Mirror of stop_checks.CODE_UNCOMMITTED_EXTS — kept here so the block decision is fully evaluable
+# from this module (single source of the gate logic for testability). Must stay in sync.
+CODE_UNCOMMITTED_EXTS = (".sh", ".js", ".py", ".ts", ".json", ".md")
+
+# admin_ops keys that constitute a documented baseline-drift override — parity with
+# stop_checks.MERGE_EXCEPTION_KEYS / check_admin_ops (#3054).
+OVERRIDE_KEYS = ("baseline_drift_override", "merge_evidence_override")
+
+
+def snapshot_uncommitted(cwd: str) -> Optional[list[str]]:
+    """Return the sorted set of uncommitted working-tree paths at `cwd`, or None on failure.
+
+    None (not []) on failure is deliberate: a failed snapshot must NOT be recorded as an empty
+    baseline (which would fail-open by making every real file look session-new... it would actually
+    over-block, but more importantly an unreadable git tree should leave NO baseline so the Stop
+    path falls back to legacy). Callers should only persist a non-None result.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "status", "--porcelain"],
+            capture_output=True, text=True, cwd=cwd, timeout=5,
+        )
+    except Exception:
+        return None
+    if result.returncode != 0:
+        return None
+    paths = [line[3:] for line in result.stdout.splitlines() if line.strip()]
+    return sorted(set(paths))
+
+
+def build_baseline_record(branch: Optional[str], paths: Iterable[str]) -> dict:
+    """Build the persisted baseline record: the branch it was captured on + the path set."""
+    return {"branch": branch, "paths": sorted(set(str(p) for p in paths))}
+
+
+def resolve_baseline(record: object, current_branch: Optional[str]) -> Optional[list[str]]:
+    """Return the baseline path list to subtract, or None to force LEGACY (fail-safe) evaluation.
+
+    None is returned when the record is missing/malformed OR was captured on a different branch than
+    `current_branch` (branch-change reset, AC4). A well-formed record whose branch matches yields its
+    path list (possibly empty — a clean-tree SessionStart).
+    """
+    if not isinstance(record, dict):
+        return None
+    paths = record.get("paths")
+    if not isinstance(paths, list):
+        return None
+    # Branch-change reset: a snapshot from another branch is not trustworthy for this branch.
+    # current_branch is compared to the recorded branch; if either is None we cannot confirm a
+    # match, so fail-safe to legacy.
+    rec_branch = record.get("branch")
+    if current_branch is None or rec_branch is None or rec_branch != current_branch:
+        return None
+    return [str(p) for p in paths]
+
+
+def is_override(admin_ops: object) -> bool:
+    """True when a documented baseline-drift override is recorded in admin_ops (#3054 parity)."""
+    if not isinstance(admin_ops, dict):
+        return False
+    return any(admin_ops.get(k) for k in OVERRIDE_KEYS)
+
+
+def attributable_delta(uncommitted: Iterable[str], baseline: Iterable[str]) -> list[str]:
+    """Uncommitted paths NOT present in the baseline snapshot (order-preserving)."""
+    base = set(str(p) for p in baseline)
+    return [f for f in uncommitted if f not in base]
+
+
+def _code_files(candidates: Iterable[str]) -> list[str]:
+    """Filter to code files subject to the Admin gate, excluding harness-managed .claude/ (#1960)."""
+    return [
+        f for f in candidates
+        if any(f.endswith(e) for e in CODE_UNCOMMITTED_EXTS)
+        and not f.startswith(".claude/")
+    ]
+
+
+def should_block(
+    uncommitted: list[str],
+    roles: Optional[dict],
+    baseline_record: object = None,
+    current_branch: Optional[str] = None,
+    admin_ops: object = None,
+) -> tuple[bool, list[str]]:
+    """Decide whether the Stop uncommitted-code gate should block, session-attributably.
+
+    Returns (block, code_files). `code_files` is the session-attributable code set that justifies
+    the block (empty when not blocking). This is the single source of truth for the gate; the
+    message formatting stays in stop_checks.check_uncommitted.
+
+    Order of precedence (matches manager scope #3810):
+      1. Empty tree                       -> no block.
+      2. Pre-collaborator phase (#1798)   -> no block (in-progress/unrelated, not an Admin gap).
+      3. Documented override (#3054)      -> no block (baseline_drift/merge_evidence override).
+      4. Baseline resolves                -> block only on the DELTA (session-attributable). AC1/AC2.
+      5. Baseline unresolved (fail-safe)  -> block on the FULL set (LEGACY). AC4 missing-snapshot.
+    """
+    if not uncommitted:
+        return False, []
+    if roles is not None and not roles.get("collaborator", False):
+        return False, []
+    if is_override(admin_ops):
+        return False, []
+    baseline = resolve_baseline(baseline_record, current_branch)
+    candidates = uncommitted if baseline is None else attributable_delta(uncommitted, baseline)
+    code_files = _code_files(candidates)
+    return (bool(code_files), code_files)

--- a/hooks/scripts/session_baseline.spec.md
+++ b/hooks/scripts/session_baseline.spec.md
@@ -1,0 +1,59 @@
+# Spec — `session_baseline` (#3810)
+
+Sibling spec for `hooks/scripts/session_baseline.py` (self-test registry:
+`inventory/harness-self-test-registry.json`). Executable unit tests:
+`hooks/scripts/session_baseline_test.py` (`python3 hooks/scripts/session_baseline_test.py`, stdlib
+`unittest`, 16 cases, no external deps).
+
+## Purpose
+
+Make the Stop hook's uncommitted-code gate (`stop_checks.check_uncommitted`) fire only on
+**session-attributable** uncommitted code — code the current session left uncommitted — never on
+pre-existing standing baseline drift present at SessionStart. Fixes the permanent false positive on
+the parked `feat/3026` canonical checkout (~40 modified + ~724 untracked, intentionally uncommitted
+per #3801). Same disease #2005 cured for `detect_session_signals`.
+
+## Data contract
+
+`governance_state["baseline_uncommitted"] = {"branch": <str|None>, "paths": [<str>, ...]}`
+
+- Written at **SessionStart** by `session_context._record_uncommitted_baseline` (advisory; failure
+  leaves the key absent).
+- Read at **Stop** by `stop_reminder` → `stop_checks.check_uncommitted` →
+  `session_baseline.should_block`.
+
+## Public API (pure, stdlib-only)
+
+- `snapshot_uncommitted(cwd) -> list[str] | None` — sorted `git status --porcelain` path set;
+  `None` on any failure (so a failed snapshot is never persisted as an empty baseline).
+- `build_baseline_record(branch, paths) -> dict` — the persisted record.
+- `resolve_baseline(record, current_branch) -> list[str] | None` — the path list to subtract, or
+  `None` (force legacy) when the record is missing/malformed **or** was captured on a different
+  branch (branch-change reset).
+- `is_override(admin_ops) -> bool` — `baseline_drift_override` / `merge_evidence_override` present
+  (parity with `check_admin_ops`, #3054).
+- `attributable_delta(uncommitted, baseline) -> list[str]` — uncommitted paths not in baseline.
+- `should_block(uncommitted, roles, baseline_record, current_branch, admin_ops) -> (bool, list)` —
+  the single source of truth for the gate decision.
+
+## Invariants (map to acceptance criteria)
+
+- **AC1** baseline == standing drift ⇒ `should_block` False (pre-existing files do NOT block).
+- **AC2** a NEW post-SessionStart uncommitted code file (not in baseline) ⇒ `should_block` True.
+  No weakening of the real Admin gate.
+- **AC3** `baseline_drift_override` (or `merge_evidence_override`) ⇒ `should_block` False.
+- **AC4** SessionStart records the baseline deterministically; a branch change (recorded branch ≠
+  current) resets it via `resolve_baseline → None`; a missing/malformed/unreadable snapshot ⇒
+  LEGACY full-set block.
+- **Fail-safe (never fail-open):** every unresolved-baseline path falls back to legacy full-set
+  evaluation. `should_block([], ...)` and pre-collaborator phase (#1798) never block.
+- **AC7 (no regression):** `check_uncommitted(uncommitted, roles)` — the legacy 2-arg call — is
+  behavior-identical to before (`baseline_record=None ⇒ legacy`).
+
+## Precedence in `should_block`
+
+1. empty tree → no block
+2. pre-collaborator (`roles['collaborator']` falsey, roles not None) → no block (#1798)
+3. documented override → no block (#3054)
+4. baseline resolves → block only on the delta (AC1/AC2)
+5. baseline unresolved → block on full set (LEGACY, fail-safe) (AC4)

--- a/hooks/scripts/session_baseline_test.py
+++ b/hooks/scripts/session_baseline_test.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Unit tests for session_baseline (#3810) — the session-attributable uncommitted gate.
+
+Stdlib-only (unittest); imports ONLY session_baseline so it runs in isolation (no dependency on the
+other hook modules or a real git tree). Run: `python3 hooks/scripts/session_baseline_test.py`.
+
+Covers the manager scope acceptance criteria at the decision level:
+  AC1  baseline == standing drift  -> should_block False (pre-existing files do NOT block)
+  AC2  new post-SessionStart file  -> should_block True  (delta blocks; no weakening)
+  AC3  baseline_drift_override     -> should_block False (parity with check_admin_ops #3054)
+  AC4  branch-change / missing snapshot -> resolve_baseline None -> LEGACY full-set block (fail-safe)
+"""
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import session_baseline as sb  # noqa: E402
+
+COLLAB = {"collaborator": True}
+
+# The parked feat/3026 standing drift, abbreviated: pre-existing uncommitted code files.
+STANDING_DRIFT = ["scripts/a.py", "hooks/scripts/b.js", "docs/c.md", "notes.txt"]
+
+
+def record(branch, paths):
+    return sb.build_baseline_record(branch, paths)
+
+
+class AC1BaselineEqualsDrift(unittest.TestCase):
+    def test_no_block_when_uncommitted_all_in_baseline(self):
+        rec = record("feat/3026", STANDING_DRIFT)
+        block, code = sb.should_block(
+            list(STANDING_DRIFT), COLLAB, rec, current_branch="feat/3026", admin_ops={})
+        self.assertFalse(block, "pre-existing baseline drift must NOT block")
+        self.assertEqual(code, [])
+
+    def test_no_block_even_though_drift_contains_code_files(self):
+        # Sanity: the drift DOES contain .py/.js/.md — the old gate blocked on these.
+        rec = record("feat/3026", STANDING_DRIFT)
+        legacy_block, _ = sb.should_block(
+            list(STANDING_DRIFT), COLLAB, None, current_branch="feat/3026", admin_ops={})
+        self.assertTrue(legacy_block, "legacy/no-baseline path DOES block on the same set")
+        new_block, _ = sb.should_block(
+            list(STANDING_DRIFT), COLLAB, rec, current_branch="feat/3026", admin_ops={})
+        self.assertFalse(new_block, "with matching baseline the identical set is suppressed")
+
+
+class AC2NewFileStillBlocks(unittest.TestCase):
+    def test_new_code_file_after_snapshot_blocks(self):
+        rec = record("feat/3026", STANDING_DRIFT)
+        uncommitted = STANDING_DRIFT + ["hooks/scripts/session_baseline.py"]  # session-authored
+        block, code = sb.should_block(
+            uncommitted, COLLAB, rec, current_branch="feat/3026", admin_ops={})
+        self.assertTrue(block, "a NEW post-SessionStart uncommitted code file MUST still block")
+        self.assertEqual(code, ["hooks/scripts/session_baseline.py"])
+
+    def test_new_noncode_file_does_not_block(self):
+        rec = record("feat/3026", STANDING_DRIFT)
+        uncommitted = STANDING_DRIFT + ["scratch/output.log"]  # not a CODE ext
+        block, code = sb.should_block(
+            uncommitted, COLLAB, rec, current_branch="feat/3026", admin_ops={})
+        self.assertFalse(block)
+        self.assertEqual(code, [])
+
+    def test_new_claude_managed_file_excluded(self):
+        rec = record("feat/3026", STANDING_DRIFT)
+        uncommitted = STANDING_DRIFT + [".claude/settings.json"]  # harness-managed (#1960)
+        block, _ = sb.should_block(
+            uncommitted, COLLAB, rec, current_branch="feat/3026", admin_ops={})
+        self.assertFalse(block, ".claude/ paths are excluded from the block")
+
+
+class AC3OverrideParity(unittest.TestCase):
+    def test_baseline_drift_override_suppresses(self):
+        uncommitted = STANDING_DRIFT + ["new.py"]  # even a genuine delta
+        block, _ = sb.should_block(
+            uncommitted, COLLAB, None, current_branch="feat/3026",
+            admin_ops={"baseline_drift_override": True})
+        self.assertFalse(block, "baseline_drift_override must suppress the block (#3054 parity)")
+
+    def test_merge_evidence_override_suppresses(self):
+        block, _ = sb.should_block(
+            ["new.py"], COLLAB, None, current_branch="b",
+            admin_ops={"merge_evidence_override": True})
+        self.assertFalse(block)
+
+    def test_is_override_helper(self):
+        self.assertTrue(sb.is_override({"baseline_drift_override": True}))
+        self.assertTrue(sb.is_override({"merge_evidence_override": 1}))
+        self.assertFalse(sb.is_override({"baseline_drift_override": False}))
+        self.assertFalse(sb.is_override({}))
+        self.assertFalse(sb.is_override(None))
+
+
+class AC4BranchChangeAndFailSafe(unittest.TestCase):
+    def test_branch_change_resets_baseline(self):
+        rec = record("feat/3026", STANDING_DRIFT)
+        # Same uncommitted set but we are now on a DIFFERENT branch -> baseline not trusted.
+        block, code = sb.should_block(
+            list(STANDING_DRIFT), COLLAB, rec, current_branch="feat/other", admin_ops={})
+        self.assertTrue(block, "a snapshot from another branch must NOT suppress (branch reset)")
+        self.assertTrue(len(code) > 0)
+
+    def test_missing_snapshot_legacy_block(self):
+        block, _ = sb.should_block(
+            list(STANDING_DRIFT), COLLAB, None, current_branch="feat/3026", admin_ops={})
+        self.assertTrue(block, "missing snapshot => legacy full-set block (fail-safe, never fail-open)")
+
+    def test_malformed_snapshot_legacy_block(self):
+        for bad in ({"branch": "feat/3026"}, {"paths": "notalist"}, "string", 42, []):
+            block, _ = sb.should_block(
+                list(STANDING_DRIFT), COLLAB, bad, current_branch="feat/3026", admin_ops={})
+            self.assertTrue(block, f"malformed record {bad!r} => fail-safe legacy block")
+
+    def test_resolve_baseline_semantics(self):
+        rec = record("b", ["x.py"])
+        self.assertEqual(sb.resolve_baseline(rec, "b"), ["x.py"])   # match
+        self.assertIsNone(sb.resolve_baseline(rec, "c"))            # branch mismatch
+        self.assertIsNone(sb.resolve_baseline(rec, None))           # unknown current branch
+        self.assertIsNone(sb.resolve_baseline(None, "b"))           # no record
+        # clean-tree SessionStart: empty paths, matching branch -> [] (not None) -> nothing blocks
+        self.assertEqual(sb.resolve_baseline(record("b", []), "b"), [])
+
+
+class GuardConditions(unittest.TestCase):
+    def test_empty_tree_no_block(self):
+        block, _ = sb.should_block([], COLLAB, None, "b", {})
+        self.assertFalse(block)
+
+    def test_pre_collaborator_no_block(self):
+        block, _ = sb.should_block(["new.py"], {"collaborator": False}, None, "b", {})
+        self.assertFalse(block, "pre-collaborator phase is not an Admin gap (#1798)")
+
+    def test_roles_none_still_evaluates(self):
+        # roles=None (unknown) must not skip the gate.
+        block, _ = sb.should_block(["new.py"], None, None, "b", {})
+        self.assertTrue(block)
+
+    def test_attributable_delta(self):
+        self.assertEqual(sb.attributable_delta(["a", "b", "c"], ["b"]), ["a", "c"])
+        self.assertEqual(sb.attributable_delta(["a"], ["a"]), [])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/hooks/scripts/session_context.py
+++ b/hooks/scripts/session_context.py
@@ -9,9 +9,34 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 if str(SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR))
 
-from governance_state import ensure_state, reset_state
+from governance_state import ensure_state, reset_state, save_state
 from wiki_router import route_wiki_context
 from wiki_wisdom import baton_protocol, governance_enforcement, post_merge_checklist
+
+
+def _record_uncommitted_baseline(state: dict, cwd: str) -> None:
+    """#3810: snapshot the uncommitted-path set + branch at SessionStart into governance_state so
+    the Stop hook can gate on session-attributable code only (the delta), never on pre-existing
+    standing baseline drift. Advisory + fail-safe: any failure leaves NO baseline recorded, so the
+    Stop path falls back to the legacy full-set block (never fail-open) and session start is never
+    broken.
+    """
+    try:
+        import subprocess
+        from session_baseline import snapshot_uncommitted, build_baseline_record
+        try:
+            branch = subprocess.check_output(
+                ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+                cwd=cwd, text=True, stderr=subprocess.DEVNULL,
+            ).strip()
+        except Exception:
+            branch = None
+        paths = snapshot_uncommitted(cwd)
+        if paths is not None:
+            state["baseline_uncommitted"] = build_baseline_record(branch, paths)
+            save_state(state)
+    except Exception:
+        pass  # advisory snapshot must never break session start
 
 
 def main() -> int:
@@ -26,6 +51,7 @@ def main() -> int:
         state = reset_state(str(cwd))
     else:
         state = ensure_state(str(cwd))
+    _record_uncommitted_baseline(state, str(cwd))  # #3810
     repo_type = state.get("repo_type", "generic")
 
     signals = []

--- a/hooks/scripts/stop_checks.py
+++ b/hooks/scripts/stop_checks.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Stop hook checking logic: admin completion and post-merge governance."""
+from __future__ import annotations
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import re
+from admin_patterns import required_admin_ops
+from github_role_resolver import derive_roles_from_github, feature_enabled as _resolver_enabled
+from wiki_wisdom import post_merge_checklist
+
+CODE_UNCOMMITTED_EXTS = (".sh", ".js", ".py", ".ts", ".json", ".md")
+
+ADMIN_STEPS = (
+    "  1. Version collision check\n"
+    "  2. git add -A && git commit\n"
+    "  3. git push -u origin <branch>\n"
+    "  4. gh pr create with Closes #N\n"
+    "  5. Wait for CI green\n"
+    "  6. gh pr merge\n"
+    "  7. If extension changed: npx vsce publish\n"
+    "  8. release-integrity-check.sh --post-publish\n"
+    "  9. gh release create vX.Y.Z\n"
+    " 10. gh issue close N"
+)
+
+
+
+_BRANCH_TICKET_RE = re.compile(r"^[a-z]+/(\d+)-")
+
+
+def ticket_from_branch(branch: str | None) -> int | None:
+    """Extract issue number from branch name like fix/2456-slug."""
+    if not branch:
+        return None
+    m = _BRANCH_TICKET_RE.match(branch)
+    return int(m.group(1)) if m else None
+
+
+def effective_roles(state_roles: dict, branch: str | None) -> dict:
+    """Resolve effective roles. When feature flag set, GitHub-derived overrides
+    local-state. Falls back to local-state on offline or feature-off (#2456).
+    """
+    if not _resolver_enabled():
+        return state_roles
+    ticket_n = ticket_from_branch(branch)
+    if ticket_n is None:
+        return state_roles
+    derived = derive_roles_from_github(ticket_n)
+    if derived is None:
+        return state_roles
+    # Merge: derived roles win on overlap; preserve any local keys derived doesn't track
+    merged = dict(state_roles)
+    merged.update(derived)
+    return merged
+
+
+def check_uncommitted(
+    uncommitted: list[str],
+    roles: dict | None = None,
+    baseline_record: object = None,
+    current_branch: str | None = None,
+    admin_ops: dict | None = None,
+) -> tuple[str | None, str | None]:
+    # #3810: gate on SESSION-ATTRIBUTABLE uncommitted code only — the delta vs the SessionStart
+    # baseline snapshot — never on pre-existing standing drift (fixes the parked-checkout false
+    # positive, same disease #2005 cured for detect_session_signals). Fail-safe: an unresolved
+    # baseline (default args, missing/malformed/branch-changed snapshot) falls back to the LEGACY
+    # full-set evaluation via should_block — never fail-open. Override parity with check_admin_ops
+    # (#3054) is honored through admin_ops. All decision precedence lives in session_baseline so it
+    # is unit-testable in isolation; message formatting stays here.
+    from session_baseline import should_block
+    block, code_files = should_block(
+        uncommitted, roles, baseline_record, current_branch, admin_ops
+    )
+    if not block:
+        return None, None
+    sample = code_files[:5]
+    ellipsis = "..." if len(code_files) > 5 else ""
+    msg = (
+        f"ADMIN ROLE INCOMPLETE — uncommitted changes.\n"
+        f"Files ({len(code_files)}): {', '.join(sample)}{ellipsis}\n"
+        f"Admin role MUST complete:\n{ADMIN_STEPS}"
+    )
+    return "Stop blocked: uncommitted changes; Admin baton incomplete.", msg
+
+
+# #3054: documented merge exceptions that satisfy the merge precondition
+# without an actual gh pr merge. Mirrors merge-evidence-pr-gate exceptions.
+MERGE_EXCEPTION_KEYS = ("merge_evidence_override", "baseline_drift_override")
+
+
+def _merge_exception_active(ops: dict) -> bool:
+    """#3054: True when a documented merge exception is recorded in admin_ops.
+
+    Exceptions: merge-evidence-override (label on issue per Epic #2517),
+    baseline-drift (explicit labelled override). Offline-graceful: when
+    merge state is indeterminate, read local admin_ops only.
+    """
+    return any(ops.get(k) for k in MERGE_EXCEPTION_KEYS)
+
+
+def check_admin_ops(
+    flags: dict, ops: dict, roles: dict, repo_type: str,
+    uncommitted: list[str] | None = None,
+    report_only_clean_exempt: bool = False,
+) -> tuple[str | None, str | None]:
+    """Check admin op completion. Returns (block_reason, message).
+
+    #3266/#3569: `report_only_clean_exempt` (a clean report-only session — lane:research,
+    lane:docs-research, or lane:docs-only — resolved by the caller) requires ZERO Admin ops and
+    suppresses the code-session Admin-role gate. These lanes are PR-less/merge-less by design, so
+    a lingering code_touched flag must not manufacture a phantom Admin obligation.
+    #3054: merge coupled to ADMIN_HANDOFF — deny unless merged OR documented exception.
+    """
+    # Phase guard (#1798 F2): Admin ops only meaningful after Collaborator completes.
+    if not roles.get("collaborator", False):
+        return None, None
+    # #1960: clean tree + no commit = code was reverted; AC#1 clean-tree pass.
+    if uncommitted is not None and not uncommitted and not ops.get("commit"):
+        return None, None
+    required = required_admin_ops(flags, repo_type, report_only_clean_exempt)
+    missing = [k for k in required if not ops.get(k)]
+    # #3054: merge exception — documented override satisfies the merge step
+    if missing and "merge" in missing and _merge_exception_active(ops):
+        missing = [k for k in missing if k != "merge"]
+    if missing:
+        reason = f"Stop blocked: missing Admin steps ({', '.join(missing)})."
+        return reason, f"Hard governance gate. Missing: {', '.join(missing)}."
+    if not report_only_clean_exempt and flags.get("code_touched") and not roles.get("admin"):
+        return (
+            "Stop blocked: Admin role not complete for code session.",
+            "Admin role not marked complete in governance state.",
+        )
+    return None, None
+
+
+def post_merge_messages(
+    signals: list[str], has_messages: bool, ops: dict | None = None
+) -> list[str]:
+    # Completion guard (#2005 Gap 1): if merge op is confirmed, admin cycle is
+    # done — suppress the checklist regardless of session signals.
+    if ops and ops.get("merge"):
+        return []
+    if "code-changed" in signals or "extension-changed" in signals:
+        return [post_merge_checklist()]
+    if not has_messages:
+        return ["Before ending: confirm checks/releases are evidence-backed and docs are synchronized."]
+    return []
+
+
+def wiki_pending_message(cwd: str, flags: dict, ops: dict) -> str | None:
+    touched = any(flags.get(k) for k in ("code_touched", "docs_touched", "extension_touched"))
+    if not touched or ops.get("issue_close"):
+        return None
+    if (Path(cwd) / "wiki" / "log.md").is_file():
+        return ("WIKI PENDING — Significant work detected. Before session end, "
+                "append wiki/log.md and update wiki/index.md if new pages were created.")
+    from runtime_paths import wiki_candidates
+    if any((c / "log.md").is_file() for c in wiki_candidates()):
+        return ("WIKI PENDING (cross-repo) — Significant work detected. "
+                "Update wiki/log.md and wiki/index.md in devenv-ops before session end.")
+    return None

--- a/hooks/scripts/stop_reminder.py
+++ b/hooks/scripts/stop_reminder.py
@@ -71,7 +71,15 @@ def main() -> int:
         messages.append("CLIENT-DEFER GUARDRAIL — " + redirect["directive"])
 
     if not block_reason:
-        block_reason, msg = check_uncommitted(uncommitted, roles)
+        # #3810: session-attributable gating — pass the SessionStart baseline snapshot + current
+        # branch + admin_ops so check_uncommitted blocks only on code THIS session left uncommitted,
+        # not on pre-existing standing drift. Unresolved baseline => legacy block (fail-safe).
+        block_reason, msg = check_uncommitted(
+            uncommitted, roles,
+            baseline_record=state.get("baseline_uncommitted"),
+            current_branch=branch,
+            admin_ops=ops,
+        )
     else:
         msg = None
     if msg:

--- a/inventory/harness-self-test-registry.json
+++ b/inventory/harness-self-test-registry.json
@@ -17,6 +17,7 @@
     { "name": "state-store-merge-reconciler", "spec": "scripts/state-store-merge-reconciler.spec.js" },
     { "name": "epic-baton-shadow-metric", "spec": "scripts/epic-baton-shadow-metric.spec.js" },
     { "name": "epic-baton-backfill-plan", "spec": "scripts/epic-baton-backfill-plan.spec.js" },
-    { "name": "state-semantics", "spec": "scripts/state-semantics.spec.js" }
+    { "name": "state-semantics", "spec": "scripts/state-semantics.spec.js" },
+    { "name": "session-baseline", "spec": "hooks/scripts/session_baseline.spec.md", "test": "hooks/scripts/session_baseline_test.py", "kind": "hook-pytest" }
   ]
 }

--- a/wiki/work-log/ticket-3810/collaborator-validation.md
+++ b/wiki/work-log/ticket-3810/collaborator-validation.md
@@ -1,0 +1,78 @@
+---
+title: "#3810 — Collaborator validation"
+type: work-log
+created: "2026-07-15"
+updated: "2026-07-15"
+tags: [ticket-3810, collaborator, hooks, stop-hook, validation]
+status: collaborator-complete
+---
+# #3810 — Collaborator validation evidence
+
+Branch: `feat/3810-stop-session-attributable-impl` (off `origin/main`).
+Role: Collaborator. Scope: `wiki/work-log/ticket-3810/manager-scope.md` (7 ACs).
+
+## What changed (PR file set — 7 files)
+
+| File | Kind | Change |
+|---|---|---|
+| `hooks/scripts/session_baseline.py` | NEW (tracked) | Pure/stdlib gate-decision module: snapshot, resolve (branch-aware), override, delta, `should_block`. |
+| `hooks/scripts/session_baseline_test.py` | NEW (tracked) | 16 `unittest` cases — AC1/AC2/AC3/AC4 + guards. Stdlib-only, no hook deps. |
+| `hooks/scripts/session_baseline.spec.md` | NEW (tracked) | Sibling spec (#1893). |
+| `hooks/scripts/stop_checks.py` | first-time TRACKED + edit | `check_uncommitted` delegates the decision to `session_baseline.should_block`; message unchanged. New optional args `baseline_record`, `current_branch`, `admin_ops` (default `None` ⇒ legacy — AC7). |
+| `hooks/scripts/stop_reminder.py` | tracked, edit | Passes `state['baseline_uncommitted']` + branch + `admin_ops` into `check_uncommitted`. |
+| `hooks/scripts/session_context.py` | tracked, edit | SessionStart snapshots `git status --porcelain` + branch into `state['baseline_uncommitted']` (advisory, fail-safe). |
+| `inventory/harness-self-test-registry.json` | edit | Registry entry `session-baseline` (#1893 discipline, AC5). |
+
+Design: SessionStart records `state["baseline_uncommitted"] = {"branch": <b>, "paths": [...]}`.
+Stop blocks only on the **delta** vs that baseline. Branch change resets it implicitly
+(`resolve_baseline` returns `None` when recorded branch ≠ current). Unresolved baseline
+(missing/malformed/branch-changed) ⇒ **legacy full-set block (fail-safe, never fail-open)**.
+Override parity (#3054): `baseline_drift_override`/`merge_evidence_override` suppress the block.
+
+## Acceptance criteria — evidence
+
+- **AC1** baseline == standing drift ⇒ no block. Isolated `check_uncommitted` returned `None`;
+  16/16 unit tests incl. `AC1BaselineEqualsDrift`; e2e: SessionStart recorded
+  `{'branch':'feat/3026-canonical','paths':['standing_a.py','standing_b.js']}` and the pre-existing
+  set did not fire the uncommitted gate.
+- **AC2** new post-SessionStart file ⇒ still blocks. Integration: adding `new.py` returned
+  `"Stop blocked: uncommitted changes; Admin baton incomplete."` with the file named in the message;
+  `AC2NewFileStillBlocks` (incl. non-code + `.claude/` exclusions).
+- **AC3** `baseline_drift_override` honored (parity #3054). Integration + `AC3OverrideParity`.
+- **AC4** SessionStart records baseline deterministically; branch change resets; missing snapshot ⇒
+  legacy block. `AC4BranchChangeAndFailSafe` (branch-mismatch, missing, malformed → block);
+  `resolve_baseline` semantics test. e2e confirmed the SessionStart write.
+- **AC5** sibling spec + registry entry present; 16 unit tests cover AC1–AC4; `py_compile` clean
+  on all 4 changed hooks.
+- **AC6** cross-family $0 consensus — see the review receipt appended by the Collaborator/Admin step.
+- **AC7** no change to unrelated Stop conditions. Legacy 2-arg `check_uncommitted(uncommitted, roles)`
+  is behavior-identical (`baseline_record=None ⇒ legacy`). client-arbitration / internal-conflict /
+  admin-ops / wiki-pending code paths untouched.
+
+## Validation commands (all green)
+
+- `python3 -m py_compile session_baseline.py stop_checks.py stop_reminder.py session_context.py` → OK
+- `python3 hooks/scripts/session_baseline_test.py` → **Ran 16 tests … OK**
+- `node scripts/governance-verify.js` → **PASS (0 tickets)** (only pre-existing #3807 advisories)
+- `node scripts/validator-discipline.js --base origin/main` → **OK — no unguarded validators**
+- `node scripts/enforcement-wiring-audit.js` → **28/28 validators enforced, 0 UNWIRED**
+
+## Isolated before/after proof (parked-checkout scenario)
+
+```
+PRE-FIX check_uncommitted (legacy 2-arg):  Stop blocked: uncommitted changes; Admin baton incomplete.
+AC1 check_uncommitted (with baseline):     None
+```
+
+## ⚠️ Discovered adjacent gap — OUT OF #3810 SCOPE (AC7), needs a follow-up ticket
+
+`stop_reminder.py` has a **second, independent** blocker that also fires on the parked checkout's
+standing drift: `classify_internal_conflict(uncommitted)` (client_arbitration_guard) returns a
+catch-all `worktree-drift` for ANY non-empty uncommitted set, and stop_reminder blocks on any
+`type != "none"` (lines ~80-88). In the full-hook e2e, after the #3810 fix the block **reason
+changed** from `"…uncommitted changes; Admin baton incomplete."` → `"…unresolved internal conflict
+requires deterministic operator resolution."`. So #3810 correctly removes the uncommitted-gate
+false positive (all 7 ACs met), but **full end-to-end unblock of the parked checkout additionally
+requires making the `worktree-drift` classifier session-attributable** — the same disease, a
+separate surface. Fixing it here would violate #3810 AC7 (no change to internal-conflict) and bundle
+two tickets. Recommend a sibling follow-up ticket. Flagged to the operator.


### PR DESCRIPTION
## Summary
Fixes the Stop-hook false positive that blocks session end on the parked feat/3026 canonical checkout's standing baseline drift (~40 modified + ~724 untracked, intentionally uncommitted per ticket 3801). Same disease ticket 2005 cured for `detect_session_signals`.

The Stop uncommitted-code gate now fires only on **session-attributable** code — the delta vs a SessionStart baseline snapshot — never on pre-existing standing drift.

## Changes (7 files)
- **`hooks/scripts/session_baseline.py`** (NEW, stdlib-only, unit-testable): SessionStart snapshot, branch-aware `resolve_baseline`, override parity, `attributable_delta`, and the `should_block` decision.
- **`hooks/scripts/session_context.py`** (SessionStart): snapshots `git status --porcelain` paths + branch into `state['baseline_uncommitted']` (advisory, fail-safe).
- **`hooks/scripts/stop_checks.py`** `check_uncommitted`: delegates the decision to `should_block`; blocks only on the delta; unresolved baseline ⇒ **legacy block (fail-safe, never fail-open)**; legacy 2-arg call behavior-identical.
- **`hooks/scripts/stop_reminder.py`**: passes baseline + branch + `admin_ops` into the gate.
- **`hooks/scripts/session_baseline.spec.md`** + **`inventory/harness-self-test-registry.json`**: spec + registry entry (validator-discipline 1893).
- **`hooks/scripts/session_baseline_test.py`**: 16 unit tests (AC1–AC4 + guards).

## Fail-safe / no-weakening
- **AC2 preserved:** a NEW post-SessionStart uncommitted code file is not in the baseline → lands in the delta → **STILL blocks** (verified via integration + e2e).
- Missing / malformed / branch-changed baseline ⇒ legacy full-set block. Never fail-open.
- Override parity: `baseline_drift_override` / `merge_evidence_override` suppress the block.

## Validation
- `python3 hooks/scripts/session_baseline_test.py` → Ran 16 tests … OK
- `py_compile` clean on all 4 changed hooks
- `node scripts/governance-verify.js` → PASS · `validator-discipline` → OK · `enforcement-wiring-audit` → 28/28
- Cross-family $0 consensus **PASS** — receipt `da0aac6aeceb212b` (meta/groq + mistral)

## Note (out of scope, AC7)
Discovered that `stop_reminder`'s separate `classify_internal_conflict` "worktree-drift" catch-all also blocks any dirty tree independently of this gate. Full parked-checkout unblock needs a follow-up ticket; not changed here (AC7 forbids touching internal-conflict).

Closes #3810