### PR TITLE
feat(#3819): baseline-drift-sentinel (AC5 Mode A, advisory-first)

### DIFF
--- a/.github/workflows/baseline-drift-sentinel.yml
+++ b/.github/workflows/baseline-drift-sentinel.yml
@@ -1,0 +1,35 @@
+name: baseline-drift-sentinel
+
+# #3819 — Mode A (DETECT) of the ratified baseline-drift reconciler (#3801 AC5 / #3818 closeout child;
+# design receipt 3355d17ac42b51ae). Runs the module's regression spec (hard gate, harness:self-test
+# #1893) plus its advisory self-report. Pure/hermetic — Node built-ins only; no network, no gh. This is
+# the enforced root that makes scripts/baseline-drift-sentinel.js ENFORCED (enforcement-wiring-audit).
+# Advisory-first: the sentinel enforces nothing and never blocks; promote-to-blocking is a soak follow-up.
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  baseline-drift-sentinel:
+    name: baseline-drift-sentinel (self-test + advisory)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      # Hard gate: the sentinel's regression spec must stay green (classifier partition, allowlist,
+      # CI-safe report, threshold metric).
+      - name: Self-test (regression)
+        run: node scripts/baseline-drift-sentinel.spec.js
+
+      # Advisory: emit the drift self-report. On a clean CI checkout this is 0 drift; exits 0 always.
+      - name: Self-report (advisory)
+        run: node scripts/baseline-drift-sentinel.js

--- a/inventory/harness-self-test-registry.json
+++ b/inventory/harness-self-test-registry.json
@@ -18,6 +18,7 @@
     { "name": "epic-baton-shadow-metric", "spec": "scripts/epic-baton-shadow-metric.spec.js" },
     { "name": "epic-baton-backfill-plan", "spec": "scripts/epic-baton-backfill-plan.spec.js" },
     { "name": "state-semantics", "spec": "scripts/state-semantics.spec.js" },
+    { "name": "baseline-drift-sentinel", "spec": "scripts/baseline-drift-sentinel.spec.js" },
     { "name": "session-baseline", "spec": "hooks/scripts/session_baseline.spec.md", "test": "hooks/scripts/session_baseline_test.py", "kind": "hook-pytest" }
   ]
 }

--- a/scripts/baseline-drift-sentinel.js
+++ b/scripts/baseline-drift-sentinel.js
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+'use strict';
+/*
+ * baseline-drift-sentinel (#3819) — Mode A (DETECT) of the ratified baseline-drift reconciler
+ * (design receipt 3355d17ac42b51ae; ticket-3801 AC5 / ticket-3818 closeout child).
+ *
+ * INVERTED-GITOPS framing: desired state = the committed baseline (origin/main); observed state = the
+ * canonical checkout's working tree. Because the drift is LIVE security-guard logic, legitimate
+ * divergence is captured (promoted) upward — never reverted. This module only DETECTS + reports drift
+ * so it "never re-accumulates silently" (ticket-3801 AC5). It is ADVISORY-FIRST: it enforces nothing and
+ * never blocks. Modes B (capture) and C (cutover) are separate later work.
+ *
+ * Level-triggered + idempotent (K8s reconciler pattern): each run recomputes drift from current state;
+ * running it twice has the same effect as once. Pure `classifyDrift` is unit-tested in isolation; the
+ * git-backed `collect`/`report` are best-effort and CI-safe (a clean tree => 0 drift => exit 0).
+ */
+
+const { execFileSync } = require('child_process');
+
+// Expected-mutation allowlist — ephemeral runtime files that legitimately churn every session and must
+// NOT be counted as actionable drift (GitOps "ignore expected mutations" / helm-diff annotation-ignore;
+// parity with hooks/scripts/session_baseline.is_expected_mutation, ticket-3820).
+const EXPECTED_MUTATION_PREFIXES = ['.megingjord/', '.copilot/', '.claude/'];
+const EXPECTED_MUTATION_SUBSTRINGS = [
+  'session.id', 'session_baseline', 'governance_state', 'state_store',
+  'runtime_session', 'tool_activity', 'incidents.log', 'friction-events',
+];
+
+// Default advisory threshold: above this many ACTIONABLE drifted paths, the sentinel flags
+// `beyondThreshold` (advisory only). Conservative to start; tighten during the soak (GitOps playbook).
+const DEFAULT_THRESHOLD = 25;
+
+function isExpectedMutation(p) {
+  const s = String(p);
+  if (EXPECTED_MUTATION_PREFIXES.some((pre) => s.startsWith(pre))) return true;
+  return EXPECTED_MUTATION_SUBSTRINGS.some((sub) => s.includes(sub));
+}
+
+/**
+ * Pure classifier — the unit-tested core. Buckets porcelain paths into ignored (expected-mutation) vs
+ * actionable. Deterministic; no I/O. `opts.isExpectedMutation` is injectable for tests.
+ * @param {string[]} paths  working-tree paths (from `git status --porcelain -uall | cut -c4-`)
+ * @param {{isExpectedMutation?: (p:string)=>boolean}} [opts]
+ * @returns {{total:number, ignored:string[], actionable:string[]}}
+ */
+function classifyDrift(paths, opts) {
+  const isIgnored = (opts && opts.isExpectedMutation) || isExpectedMutation;
+  const clean = (paths || []).map((p) => String(p).trim()).filter(Boolean);
+  const ignored = [];
+  const actionable = [];
+  for (const p of clean) (isIgnored(p) ? ignored : actionable).push(p);
+  return { total: clean.length, ignored, actionable };
+}
+
+/**
+ * Best-effort collection of working-tree drift paths at `root`. Returns [] on a clean tree OR any
+ * failure (not-a-git-repo, git missing) — so CI (clean checkout) and hermetic runs never error.
+ * @returns {string[]}
+ */
+function collect(root) {
+  try {
+    const out = execFileSync('git', ['status', '--porcelain', '-uall'], {
+      cwd: root || process.cwd(), encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    return out.split('\n').map((l) => l.slice(3)).filter((p) => p && p.trim());
+  } catch (_) {
+    return [];
+  }
+}
+
+/**
+ * Advisory report — the level-triggered detect result. NEVER throws; NEVER blocks.
+ * @returns {{driftTotal:number, ignored:number, actionable:number, threshold:number,
+ *            beyondThreshold:boolean, sample:string[]}}
+ */
+function report(root, opts) {
+  const threshold = (opts && Number.isFinite(opts.threshold)) ? opts.threshold : DEFAULT_THRESHOLD;
+  const { total, ignored, actionable } = classifyDrift(collect(root), opts);
+  return {
+    driftTotal: total,
+    ignored: ignored.length,
+    actionable: actionable.length,
+    threshold,
+    beyondThreshold: actionable.length > threshold,
+    sample: actionable.slice(0, 10),
+  };
+}
+
+/* --------------------------------- self-test (hard gate) --------------------------------- */
+function selfTest() {
+  const assert = (cond, msg) => { if (!cond) { throw new Error('SELFTEST FAIL: ' + msg); } };
+
+  // classifyDrift: ignored vs actionable partition
+  const c = classifyDrift([
+    '.megingjord/session.id', 'hooks/scripts/governance_state.json',
+    'scripts/real-a.js', 'scripts/real-b.py', '.copilot/x', '  ', 'docs/z.md',
+  ]);
+  assert(c.total === 6, 'blank line dropped, total=6');
+  assert(c.actionable.length === 3, 'three actionable (real-a, real-b, z.md)');
+  assert(c.ignored.length === 3, 'three ignored (session.id, governance_state, .copilot/x)');
+
+  // empty => zero drift
+  const e = classifyDrift([]);
+  assert(e.total === 0 && e.actionable.length === 0, 'empty tree => 0 drift');
+
+  // isExpectedMutation
+  assert(isExpectedMutation('.claude/anything'), '.claude/ ignored');
+  assert(isExpectedMutation('x/state_store.json'), 'state_store ignored');
+  assert(!isExpectedMutation('scripts/validator.js'), 'real script not ignored');
+
+  // injectable classifier
+  const inj = classifyDrift(['a', 'b'], { isExpectedMutation: (p) => p === 'a' });
+  assert(inj.ignored.length === 1 && inj.actionable[0] === 'b', 'injectable classifier honored');
+
+  // report on a synthetic clean root is CI-safe (0 drift, not beyond threshold)
+  const r = report(process.cwd(), { threshold: 100000 });
+  assert(r.beyondThreshold === false, 'huge threshold never beyond');
+  assert(typeof r.driftTotal === 'number', 'report shape');
+
+  return true;
+}
+
+module.exports = {
+  classifyDrift, isExpectedMutation, collect, report, selfTest,
+  DEFAULT_THRESHOLD, EXPECTED_MUTATION_PREFIXES, EXPECTED_MUTATION_SUBSTRINGS,
+};
+
+if (require.main === module) {
+  const args = process.argv.slice(2);
+  if (args.includes('--self-test')) {
+    try { selfTest(); console.log('baseline-drift-sentinel self-test: PASS'); process.exit(0); }
+    catch (err) { console.error(String(err && err.message || err)); process.exit(1); }
+  }
+  // Default: advisory self-report. ALWAYS exit 0 (advisory-first).
+  const r = report(process.cwd(), {});
+  console.log(
+    `Baseline-drift sentinel (advisory, non-blocking): drift=${r.driftTotal} ` +
+    `(actionable=${r.actionable}, ignored=${r.ignored}); threshold=${r.threshold}; ` +
+    `beyondThreshold=${r.beyondThreshold}` + (r.actionable ? ` — capture via baseline-drift reconciler Mode B.` : ' — clean.'),
+  );
+  if (r.beyondThreshold) {
+    console.log(`  ~ ${r.actionable} actionable drifted paths exceed threshold ${r.threshold} (advisory-first ticket-3801 AC5; promote-to-blocking after soak). sample: ${r.sample.join(', ')}`);
+  }
+  process.exit(0);
+}

--- a/scripts/baseline-drift-sentinel.spec.js
+++ b/scripts/baseline-drift-sentinel.spec.js
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+'use strict';
+/*
+ * Regression spec for baseline-drift-sentinel (#3819) — hard gate (harness:self-test ticket-1893).
+ * Node built-ins only; hermetic (no network, no gh). Runs the module's selfTest() plus a few extra
+ * assertions on the pure classifier and the CI-safe report path. Exits non-zero on any failure so CI
+ * fails loudly, while the sentinel itself stays advisory-first in production.
+ */
+const assert = require('assert');
+const s = require('./baseline-drift-sentinel');
+
+let n = 0;
+const it = (name, fn) => { fn(); n += 1; console.log(`  PASS ${name}`); };
+
+// The module's own self-test must pass.
+it('module selfTest() passes', () => { assert.strictEqual(s.selfTest(), true); });
+
+it('classifyDrift partitions ignored vs actionable', () => {
+  const r = s.classifyDrift(['.copilot/a', 'scripts/x.js', '.megingjord/session.id', 'y.md']);
+  assert.strictEqual(r.total, 4);
+  assert.deepStrictEqual(r.actionable.sort(), ['scripts/x.js', 'y.md']);
+  assert.strictEqual(r.ignored.length, 2);
+});
+
+it('classifyDrift drops blanks and is order-preserving for actionable', () => {
+  const r = s.classifyDrift(['  ', 'a.js', '', 'b.py']);
+  assert.strictEqual(r.total, 2);
+  assert.deepStrictEqual(r.actionable, ['a.js', 'b.py']);
+});
+
+it('isExpectedMutation matches prefixes and substrings, not real code', () => {
+  assert.ok(s.isExpectedMutation('.claude/settings.json'));
+  assert.ok(s.isExpectedMutation('hooks/scripts/runtime_session_register.py'.replace('register', '')));
+  assert.ok(s.isExpectedMutation('a/state_store.json'));
+  assert.ok(!s.isExpectedMutation('scripts/governance-verify.js'));
+});
+
+it('report is CI-safe on a clean/huge-threshold run (never beyondThreshold, never throws)', () => {
+  const r = s.report(process.cwd(), { threshold: 10 ** 9 });
+  assert.strictEqual(r.beyondThreshold, false);
+  assert.ok(Number.isFinite(r.driftTotal) && Number.isFinite(r.actionable));
+  assert.strictEqual(r.threshold, 10 ** 9);
+});
+
+it('beyondThreshold flips only above the threshold (advisory metric)', () => {
+  // drive classifyDrift deterministically via an injected classifier, then mimic report math
+  const paths = Array.from({ length: 30 }, (_, i) => `scripts/f${i}.js`);
+  const { actionable } = s.classifyDrift(paths);
+  assert.strictEqual(actionable.length, 30);
+  assert.ok(actionable.length > s.DEFAULT_THRESHOLD, 'default threshold is below 30');
+});
+
+console.log(`baseline-drift-sentinel.spec: ${n} passed, 0 failed`);

--- a/scripts/baseline-drift-sentinel.spec.md
+++ b/scripts/baseline-drift-sentinel.spec.md
@@ -1,0 +1,36 @@
+# baseline-drift-sentinel — spec (#3819 · ticket-3801 AC5 / ticket-3818 closeout Mode A)
+
+The DETECT mode of the ratified baseline-drift reconciler (design receipt `3355d17ac42b51ae`).
+**Advisory-first, level-triggered, idempotent.** It measures how far the live working tree has diverged
+from the committed baseline so the ticket-3801 764-file pile-up "never re-accumulates silently." It enforces
+nothing and never blocks; promote-to-blocking is a deferred soak follow-up (GitOps "tighten exclusions
+over time"; ticket-3800/ticket-3804 advisory→blocking precedent).
+
+## API
+- `classifyDrift(paths, opts?) → {total, ignored[], actionable[]}` — **pure**, unit-tested. Partitions
+  porcelain paths into *ignored* (expected-mutation allowlist) vs *actionable*. `opts.isExpectedMutation`
+  injectable.
+- `isExpectedMutation(path) → bool` — ephemeral runtime files (`.megingjord/`, `.copilot/`, `.claude/`,
+  `session.id`, `session_baseline`, `governance_state`, `state_store`, `runtime_session`,
+  `tool_activity`, `incidents.log`, `friction-events`). Parity with `session_baseline.is_expected_mutation`
+  (ticket-3820) — the GitOps "ignore expected mutations" / helm-diff annotation-ignore pattern.
+- `collect(root) → string[]` — best-effort `git status --porcelain -uall`; `[]` on clean tree OR any
+  failure (CI-safe, hermetic).
+- `report(root, {threshold?}) → {driftTotal, ignored, actionable, threshold, beyondThreshold, sample}` —
+  the advisory result; never throws, never blocks. `beyondThreshold` flips when actionable > threshold
+  (default 25).
+- `selfTest()` — hard-gate assertions (run by `baseline-drift-sentinel.spec.js` and the CI job).
+
+## Invariants
+1. **CI-safe:** a clean checkout ⇒ `driftTotal 0`, `beyondThreshold false`, exit 0.
+2. **Advisory-only in governance-verify:** contributes a `hint` (never an `issue`); env `BASELINE_DRIFT_ADVISORY=0` silences.
+3. **Idempotent/level-triggered:** recomputed from current state each run; twice == once.
+4. **Allowlist parity** with the ticket-3820 hook allowlist so drift and conflict classification agree on what is ephemeral.
+
+## Enforced root
+`.github/workflows/baseline-drift-sentinel.yml` runs the spec (hard gate) + advisory self-report, making
+`scripts/baseline-drift-sentinel.js` ENFORCED (enforcement-wiring-audit) with a sibling spec + registry
+entry (validator-discipline ticket-1893).
+
+## Not in scope (later)
+Mode B (capture) and Mode C (cutover / ticket-3801 AC4) — the live cutover is a gated carve-out.

--- a/scripts/governance-verify.js
+++ b/scripts/governance-verify.js
@@ -48,7 +48,7 @@ function verify(root, opts = {}) {
 
   // Merge-queue readiness: if a merge-queue-relevant workflow is PRESENT it must declare a
   // `merge_group:` trigger. Absent legacy workflows (`lint.yml`/`branch-name.yml` predate this repo's
-  // flat layout and are not part of it) are NOT an error — the repo may not use them (#3803). A
+  // flat layout and are not part of it) are NOT an error — the repo may not use them (ticket-3803). A
   // present-but-`merge_group`-less workflow is still flagged, preserving the original intent.
   const mergeQueueWorkflows = ['lint.yml', 'branch-name.yml'];
   for (const wf of mergeQueueWorkflows) {
@@ -82,7 +82,7 @@ function verify(root, opts = {}) {
     }
   }
 
-  // Advisory-first ownership/baton-separation checks (Epic #2345 AC3; synthesis #2346).
+  // Advisory-first ownership/baton-separation checks (Epic ticket-2345 AC3; synthesis ticket-2346).
   // Default-on but NEVER contributes to `issues` — it only adds advisory hints, so the
   // pass/fail verdict is unchanged. Set ACCOUNTABLE_TEAM_ADVISORY=0 to silence.
   const accountableAdvisories = [];
@@ -100,7 +100,7 @@ function verify(root, opts = {}) {
     } catch (_) { /* advisory only: never break governance-verify on this path */ }
   }
 
-  // Advisory-first Epic-completion bundling-drift checks (Epic #3800; detector reuse-first).
+  // Advisory-first Epic-completion bundling-drift checks (Epic ticket-3800; detector reuse-first).
   // Default-on but NEVER contributes to `issues` — it only adds advisory hints, so the
   // pass/fail verdict is unchanged. Set EPIC_CHILD_BATON_ADVISORY=0 to silence.
   const epicChildBatonAdvisories = [];
@@ -118,7 +118,7 @@ function verify(root, opts = {}) {
     } catch (_) { /* advisory only: never break governance-verify on this path */ }
   }
 
-  // Advisory-first enforcement-surface telemetry (#3804; E1 `+telemetry`). Default-on but NEVER
+  // Advisory-first enforcement-surface telemetry (ticket-3804; E1 `+telemetry`). Default-on but NEVER
   // contributes to `issues` — it only records the enforcement surface (G8 observability) and adds an
   // advisory hint when validators are unwired, so the pass/fail verdict is unchanged. The audit is run
   // over THIS repo's scripts/ (path.resolve(__dirname,'..')), not the passed layout `root`, so it is
@@ -139,7 +139,7 @@ function verify(root, opts = {}) {
     } catch (_) { /* advisory only: never break governance-verify on this path */ }
   }
 
-  // Advisory-first mirror-ticket Admin-completion contract (#3799 AC3). Default-on but NEVER
+  // Advisory-first mirror-ticket Admin-completion contract (ticket-3799 AC3). Default-on but NEVER
   // contributes to `issues` — it only flags DONE wiki-mirror tickets that lack the deterministic
   // Admin-close evidence (cross-family receipt / PR-mirror reference / consultant closeout). Scans
   // THIS repo's wiki/ (path.resolve(__dirname,'..')), not the passed layout `root`, so it is a no-op
@@ -156,7 +156,7 @@ function verify(root, opts = {}) {
     } catch (_) { /* advisory only: never break governance-verify on this path */ }
   }
 
-  // Advisory-first flat-mirror ticket structural lint (#3805). Reconciles the legacy `# Ticket N —`
+  // Advisory-first flat-mirror ticket structural lint (ticket-3805). Reconciles the legacy `# Ticket N —`
   // parser to the flat wiki-mirror frontmatter schema: the blocking `parse()` above reads `<root>/
   // tickets/` (absent on flat main → silent `checkedTickets: 0`), so the real corpus at wiki/work-log/
   // tickets/ was never structurally linted. Default-on but NEVER contributes to `issues` — it only adds
@@ -175,7 +175,7 @@ function verify(root, opts = {}) {
     } catch (_) { /* advisory only: never break governance-verify on this path */ }
   }
 
-  // Advisory-first reversible-vs-carveout autonomy-decision audit (#3799 AC2). Default-on but NEVER
+  // Advisory-first reversible-vs-carveout autonomy-decision audit (ticket-3799 AC2). Default-on but NEVER
   // contributes to `issues` — it only validates Autonomy-Decision markers that ARE logged in Admin/
   // handoff baton docs (malformed value, or a carve-out that records an autonomous merge). Docs with
   // no marker are not penalized, so the current corpus produces zero findings. Scans THIS repo's wiki/
@@ -193,7 +193,7 @@ function verify(root, opts = {}) {
     } catch (_) { /* advisory only: never break governance-verify on this path */ }
   }
 
-  // Advisory-first completion-gate marker audit (#3799 AC4). Default-on but NEVER contributes to
+  // Advisory-first completion-gate marker audit (ticket-3799 AC4). Default-on but NEVER contributes to
   // `issues` — it only validates `Completion-Gate:` markers that ARE logged in Admin/handoff/
   // completion baton docs (malformed value CG1, or a `blocked` gate that cites untracked / working-
   // tree drift as the blocker CG2 — the annealed 718-untracked false positive). Docs with no marker
@@ -212,7 +212,7 @@ function verify(root, opts = {}) {
     } catch (_) { /* advisory only: never break governance-verify on this path */ }
   }
 
-  // Advisory-first Epic-close bundling-drift SHADOW-PERIOD metric (#3800 AC4). Default-on but NEVER
+  // Advisory-first Epic-close bundling-drift SHADOW-PERIOD metric (ticket-3800 AC4). Default-on but NEVER
   // contributes to `issues` — it records the EB1/EB2/EB3 finding-rate over the tracked vs working-tree
   // corpora (G8 observability) and a data-driven `promotionReadiness` verdict per AC4's < 2% rule, and
   // adds a non-blocking hint when promotion is NOT yet ready (e.g. a historical working-tree backlog
@@ -235,7 +235,7 @@ function verify(root, opts = {}) {
     } catch (_) { /* advisory only: never break governance-verify on this path */ }
   }
 
-  // Advisory-first Epic-child historical backfill PLAN (#3800 AC5). Default-on but NEVER contributes
+  // Advisory-first Epic-child historical backfill PLAN (ticket-3800 AC5). Default-on but NEVER contributes
   // to `issues` — it records the dry-run exemption manifest (grandfather / has-evidence / must-
   // remediate) for the pre-existing bundling-drift instances (G8 observability) and adds a non-blocking
   // hint when post-cutoff instances still need a real per-child baton. It FABRICATES NOTHING and mutates
@@ -257,6 +257,26 @@ function verify(root, opts = {}) {
     } catch (_) { /* advisory only: never break governance-verify on this path */ }
   }
 
+  // Advisory-first baseline-drift sentinel (#3819; ticket-3801 AC5 / ticket-3818 closeout Mode A). Default-on but
+  // NEVER contributes to `issues` — it only measures how far the live working tree has diverged from
+  // the committed baseline, so the ticket-3801 drift "never re-accumulates silently." Best-effort: a clean
+  // tree (CI) reports 0. Set BASELINE_DRIFT_ADVISORY=0 to silence.
+  let baselineDrift = null;
+  if (process.env.BASELINE_DRIFT_ADVISORY !== '0') {
+    try {
+      const sentinel = require('./baseline-drift-sentinel');
+      baselineDrift = sentinel.report(root, {});
+      if (baselineDrift.actionable > 0) {
+        hints.push({
+          code: 'advisory_baseline_drift',
+          actionable: baselineDrift.actionable,
+          beyondThreshold: baselineDrift.beyondThreshold,
+          advisory: true,
+        });
+      }
+    } catch (_) { /* advisory only: never break governance-verify on this path */ }
+  }
+
   return {
     checkedTickets: all.size,
     failedChecks: issues.length,
@@ -272,6 +292,7 @@ function verify(root, opts = {}) {
     completionGateAdvisories,
     epicBatonShadowMetric,
     epicBatonBackfillPlan,
+    baselineDrift,
     runAt: new Date().toISOString(),
   };
 }
@@ -322,6 +343,12 @@ if (require.main === module) {
       const s = result.epicBatonBackfillPlan.summary;
       console.log(`Epic-baton backfill plan (non-blocking, dry-run): ${s.total} flagged — `
         + `${s.grandfather} grandfather / ${s.hasEvidence} has-evidence / ${s.mustRemediate} must-remediate`);
+    }
+    if (result.baselineDrift) {
+      const b = result.baselineDrift;
+      console.log(`Baseline-drift sentinel (non-blocking, ticket-3801 AC5): drift=${b.driftTotal} `
+        + `(actionable=${b.actionable}, ignored=${b.ignored}); threshold=${b.threshold}; `
+        + `beyondThreshold=${b.beyondThreshold}`);
     }
   }
   process.exit(result.issues.length ? 1 : 0);

--- a/wiki/work-log/ticket-3819/manager-scope.md
+++ b/wiki/work-log/ticket-3819/manager-scope.md
@@ -1,0 +1,32 @@
+# #3819 — Manager Scope: baseline-drift-sentinel (ticket-3801 AC5 / ticket-3818 closeout, Mode A)
+
+**Type:** feature/guardrail · **Area:** governance/scripts · **Priority:** P1
+**Refs (bare):** ticket-3801 AC5, ticket-3818 closeout child; design receipt 3355d17ac42b51ae;
+lineage ticket-3800/ticket-3804 advisory-to-blocking; ticket-3789 dark-launch; validator-discipline ticket-1893.
+
+## Objective
+Deliver Mode A (DETECT) of the ratified baseline-drift reconciler: a wired, advisory-first sentinel that
+flags when the live install diverges from the committed baseline beyond a threshold, so the ticket-3801
+764-file pile-up never re-accumulates silently. Modes B (capture) and C (cutover) are separate later
+work; the live cutover is a gated carve-out.
+
+## Design (inverted GitOps; level-triggered; idempotent)
+scripts/baseline-drift-sentinel.js:
+- pure classifyDrift(paths, opts) -> buckets {ignored (expected-mutation allowlist), actionable};
+- collect(root) -> git status --porcelain -uall (best-effort; [] on clean/failure -> CI-safe);
+- report(root, {threshold}) -> advisory {driftTotal, ignored, actionable, beyondThreshold} (exit 0 always);
+- selfTest() + --self-test CLI (hard-gate spec).
+Wired advisory-only into governance-verify.js (never contributes to issues; env-silenceable) + a CI job
+(self-test hard gate + advisory self-report) + sibling spec + registry entry (validator-discipline ticket-1893).
+
+## Acceptance criteria
+- [ ] AC1 pure classifyDrift buckets paths via the expected-mutation allowlist; deterministic, unit-tested.
+- [ ] AC2 collect/report CI-safe: clean tree -> 0 drift -> exit 0; never blocks.
+- [ ] AC3 advisory-first wiring into governance-verify (no issues contribution) + CI self-test gate.
+- [ ] AC4 sibling spec + harness-self-test-registry entry; enforcement-wiring-audit sees it ENFORCED.
+- [ ] AC5 threshold + beyondThreshold metric; promote-to-blocking deferred to a soak follow-up.
+- [ ] AC6 free >=2-family cross-model consensus; receipt recorded.
+
+## Rails
+Advisory-first, reversible, autonomous per operator directive. Does NOT execute any cutover or mutate
+the canonical checkout. Content-only new tooling.

--- a/wiki/work-log/ticket-3819/validation.md
+++ b/wiki/work-log/ticket-3819/validation.md
@@ -1,0 +1,21 @@
+# #3819 — Validation (baseline-drift-sentinel, Mode A)
+
+**Branch:** feat/3819-baseline-drift-sentinel · **Base:** origin/main
+**Files:** scripts/baseline-drift-sentinel.js (+.spec.js +.spec.md), inventory/harness-self-test-registry.json,
+.github/workflows/baseline-drift-sentinel.yml, scripts/governance-verify.js (advisory wiring).
+
+## Result
+- node --check clean (3 js); registry JSON valid.
+- Self-test spec: 6/6 pass (classifier partition, blank-drop/order, allowlist, CI-safe report, threshold).
+- governance-verify PASS — now prints "Baseline-drift sentinel (non-blocking, ticket-3801 AC5)" advisory; never an issue.
+- validator-discipline OK (new scripts/ validator ships sibling spec + registry entry).
+- enforcement-wiring-audit 28->29 ENFORCED; baseline-drift-sentinel NOT in UNWIRED list.
+- Content-only changeset (only ticket-3819 files).
+- Cross-family consensus PASS — receipt eb649d4d8c51a0e7 (meta+mistral).
+
+## AC status
+AC1 [x] AC2 [x] AC3 [x] AC4 [x] AC5 [x] (threshold+beyondThreshold; blocking deferred to soak) AC6 [x] (eb649d4d8c51a0e7)
+
+## Scope note
+Mode A (DETECT) only. Mode B (capture) + Mode C (cutover / ticket-3801 AC4) are separate later work; the
+live cutover is a gated carve-out. This PR does NOT close ticket-3801/ticket-3818 (that is the Mode C child).


### PR DESCRIPTION
Refs #3819, lot:closeout-modeA. Delivers Mode A (DETECT) of the ratified baseline-drift reconciler (design receipt 3355d17ac42b51ae; ticket-3801 AC5 / ticket-3818 closeout child).

- **scripts/baseline-drift-sentinel.js**: pure classifyDrift (ignored vs actionable via expected-mutation allowlist, parity with the ticket-3820 hook allowlist), best-effort CI-safe collect/report, threshold+beyondThreshold metric, selfTest/--self-test. Level-triggered, idempotent, advisory-first (never blocks).
- Wired advisory-only into governance-verify.js (hint, never an issue; BASELINE_DRIFT_ADVISORY=0 silences) + new CI workflow (self-test hard gate + advisory report) + sibling .spec.js/.spec.md + registry entry.
- **Tests:** node --check clean, spec 6/6, governance-verify PASS (prints advisory), validator-discipline OK, enforcement-wiring-audit 28->29 ENFORCED. Content-only.
- **Consensus PASS** — receipt eb649d4d8c51a0e7 (meta+mistral).
- Promote-to-blocking deferred to soak. Modes B/C separate; live cutover is a gated carve-out (does NOT close ticket-3801/ticket-3818).