### PR TITLE
fix(#3821): detect_uncommitted_changes first-line porcelain parse

### DIFF
--- a/hooks/scripts/git_checks.py
+++ b/hooks/scripts/git_checks.py
@@ -48,9 +48,14 @@ def detect_uncommitted_changes(cwd: str) -> list[str]:
             capture_output=True, text=True, cwd=cwd, timeout=5,
         )
         if result.returncode == 0 and result.stdout.strip():
+            # #3821: split with splitlines() and DO NOT strip the whole stdout first. A
+            # `result.stdout.strip()` would eat the leading status space of the FIRST porcelain line,
+            # shifting its `line[3:]` by one and corrupting that path (e.g. ".gitignore" -> "gitignore").
+            # This must parse identically to session_baseline.snapshot_uncommitted so the Stop
+            # session-attributable delta (#3820) is exact.
             return [
                 line[3:]
-                for line in result.stdout.strip().split("\n")
+                for line in result.stdout.splitlines()
                 if line.strip()
             ]
     except Exception:

--- a/hooks/scripts/git_checks.spec.md
+++ b/hooks/scripts/git_checks.spec.md
@@ -1,0 +1,19 @@
+# git_checks — porcelain parsing spec (#3821)
+
+`detect_uncommitted_changes(cwd)` returns the working-tree paths from `git status --porcelain`, one per
+entry, parsed as `line[3:]` (XY status + space, then path).
+
+## Invariant (the #3821 fix)
+Parse with `result.stdout.splitlines()` — **never** `result.stdout.strip().split("\n")`. A whole-output
+`.strip()` removes the leading status space of the **first** porcelain line (a modified file's X column
+is a space), shifting that line's `line[3:]` by one and corrupting the first path
+(`.gitignore` → `gitignore`). The per-line `if line.strip()` guard drops blank lines.
+
+This MUST parse identically to `session_baseline.snapshot_uncommitted` so the Stop hook's
+session-attributable delta (#3820, `session_attributable_subset`) is exact — otherwise a single
+mis-parsed first entry leaks past the baseline subtraction and `classify_internal_conflict` false-blocks
+session end with `worktree-drift`.
+
+## Tests
+`hooks/scripts/git_checks_test.py` (hermetic, monkeypatched subprocess): first-path-not-corrupted,
+all-paths-intact, matches-snapshot_uncommitted-parsing, empty/failure-safe.

--- a/hooks/scripts/git_checks_test.py
+++ b/hooks/scripts/git_checks_test.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Regression tests for git_checks.detect_uncommitted_changes porcelain parsing (#3821).
+
+Stdlib-only (unittest); hermetic — monkeypatches subprocess.run so no real git tree is needed. The bug:
+`result.stdout.strip().split("\\n")` ate the leading status space of the FIRST porcelain line, shifting
+its `line[3:]` and corrupting that path (".gitignore" -> "gitignore"), so the Stop session-attributable
+delta (#3820) leaked exactly one item and false-blocked. The fix parses with `splitlines()` (no
+whole-output strip), identical to session_baseline.snapshot_uncommitted.
+
+Run: `python3 hooks/scripts/git_checks_test.py`.
+"""
+from __future__ import annotations
+
+import sys
+import types
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import git_checks  # noqa: E402
+
+
+class _FakeResult:
+    def __init__(self, stdout, returncode=0):
+        self.stdout = stdout
+        self.returncode = returncode
+        self.stderr = ""
+
+
+def _patched_run(stdout):
+    """Return a subprocess.run stand-in that yields `stdout` regardless of args."""
+    def _run(*_args, **_kwargs):
+        return _FakeResult(stdout)
+    return _run
+
+
+# Real `git status --porcelain` output: XY + space + path. A modified file's X is a space, so the whole
+# blob begins with a leading space that a naive .strip() would consume.
+PORCELAIN = " M .gitignore\n?? scripts/new.js\n M hooks/scripts/a.py\n"
+
+
+class FirstLineParse(unittest.TestCase):
+    def setUp(self):
+        self._orig = git_checks.subprocess.run
+
+    def tearDown(self):
+        git_checks.subprocess.run = self._orig
+
+    def test_first_path_not_corrupted(self):
+        git_checks.subprocess.run = _patched_run(PORCELAIN)
+        out = git_checks.detect_uncommitted_changes("/nonexistent")
+        # AC1: the FIRST entry keeps its leading dot — not "gitignore".
+        self.assertEqual(out[0], ".gitignore")
+        self.assertNotIn("gitignore", out, "the corrupted (dot-less) form must not appear")
+
+    def test_all_paths_intact(self):
+        git_checks.subprocess.run = _patched_run(PORCELAIN)
+        out = git_checks.detect_uncommitted_changes("/nonexistent")
+        self.assertEqual(out, [".gitignore", "scripts/new.js", "hooks/scripts/a.py"])
+
+    def test_matches_snapshot_uncommitted_parsing(self):
+        # AC2: detect_uncommitted_changes must parse identically to snapshot_uncommitted (both line[3:]
+        # over splitlines()). Compare the two parse strategies over the same blob.
+        import session_baseline as sb  # noqa: E402
+        git_checks.subprocess.run = _patched_run(PORCELAIN)
+        detect = git_checks.detect_uncommitted_changes("/nonexistent")
+        sb_orig = sb.subprocess.run
+        try:
+            sb.subprocess.run = _patched_run(PORCELAIN)
+            snap = sb.snapshot_uncommitted("/nonexistent")
+        finally:
+            sb.subprocess.run = sb_orig
+        self.assertEqual(set(detect), set(snap))
+
+    def test_empty_and_failure_safe(self):
+        git_checks.subprocess.run = _patched_run("")
+        self.assertEqual(git_checks.detect_uncommitted_changes("/x"), [])
+        git_checks.subprocess.run = _patched_run(_FakeResult("x", returncode=1).stdout)  # noqa
+        # returncode 1 path
+        git_checks.subprocess.run = lambda *a, **k: _FakeResult("data", returncode=1)
+        self.assertEqual(git_checks.detect_uncommitted_changes("/x"), [])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/inventory/harness-self-test-registry.json
+++ b/inventory/harness-self-test-registry.json
@@ -20,6 +20,6 @@
     { "name": "state-semantics", "spec": "scripts/state-semantics.spec.js" },
     { "name": "baseline-drift-sentinel", "spec": "scripts/baseline-drift-sentinel.spec.js" },
     { "name": "session-baseline", "spec": "hooks/scripts/session_baseline.spec.md", "test": "hooks/scripts/session_baseline_test.py", "kind": "hook-pytest" },
-    { "name": "git-checks-porcelain", "test": "hooks/scripts/git_checks_test.py", "kind": "hook-pytest" }
+    { "name": "git-checks-porcelain", "spec": "hooks/scripts/git_checks.spec.md", "test": "hooks/scripts/git_checks_test.py", "kind": "hook-pytest" }
   ]
 }

--- a/inventory/harness-self-test-registry.json
+++ b/inventory/harness-self-test-registry.json
@@ -19,6 +19,7 @@
     { "name": "epic-baton-backfill-plan", "spec": "scripts/epic-baton-backfill-plan.spec.js" },
     { "name": "state-semantics", "spec": "scripts/state-semantics.spec.js" },
     { "name": "baseline-drift-sentinel", "spec": "scripts/baseline-drift-sentinel.spec.js" },
-    { "name": "session-baseline", "spec": "hooks/scripts/session_baseline.spec.md", "test": "hooks/scripts/session_baseline_test.py", "kind": "hook-pytest" }
+    { "name": "session-baseline", "spec": "hooks/scripts/session_baseline.spec.md", "test": "hooks/scripts/session_baseline_test.py", "kind": "hook-pytest" },
+    { "name": "git-checks-porcelain", "test": "hooks/scripts/git_checks_test.py", "kind": "hook-pytest" }
   ]
 }

--- a/wiki/work-log/ticket-3821/manager-scope.md
+++ b/wiki/work-log/ticket-3821/manager-scope.md
@@ -1,0 +1,27 @@
+# #3821 — Manager Scope: fix detect_uncommitted_changes first-line porcelain parse
+
+**Type:** bug · **Area:** hooks/git · **Priority:** P2
+**Refs (bare):** discovered deploying ticket-3820; ticket-3810 baseline substrate; ticket-3801 standing drift.
+
+## Problem
+git_checks.detect_uncommitted_changes runs result.stdout.strip().split(newline) then line[3:]. The
+whole-output strip removes the leading status space of the FIRST porcelain line, shifting its line[3:]
+by one and corrupting that one path (e.g. .gitignore -> gitignore). session_baseline.snapshot_uncommitted
+uses splitlines (no whole-output strip), so the Stop baseline and the Stop uncommitted set disagree on
+exactly the first entry. should_block masked it (its _code_files filter drops the non-code first item),
+but the ticket-3820 session-attributable conflict path has no code filter, so the 1 mis-parsed item leaks
+-> classify_internal_conflict -> worktree-drift -> false Stop block.
+
+## Fix (1 line, root cause)
+detect_uncommitted_changes: result.stdout.strip().split(newline) -> result.stdout.splitlines()
+(the existing per-line if line.strip() guard already drops blanks). Parses identically to
+snapshot_uncommitted; first path no longer corrupted.
+
+## Acceptance criteria
+- [ ] AC1 first porcelain entry parses with full path (.gitignore stays .gitignore).
+- [ ] AC2 detect_uncommitted_changes set == snapshot_uncommitted set on the same tree.
+- [ ] AC3 regression test; py_compile clean.
+- [ ] AC4 free >=2-family cross-model consensus; receipt recorded.
+
+## Rails
+Pure correctness fix to a live guard; reversible; makes parsing MORE correct. Live deploy follows merge.

--- a/wiki/work-log/ticket-3821/validation.md
+++ b/wiki/work-log/ticket-3821/validation.md
@@ -1,0 +1,19 @@
+# #3821 — Validation
+
+**Branch:** fix/3821-detect-uncommitted-firstline-parse · **Base:** origin/main
+**Files:** hooks/scripts/git_checks.py (1-line parse fix), hooks/scripts/git_checks_test.py (new, 4 tests),
+inventory/harness-self-test-registry.json (git-checks-porcelain entry).
+
+## Result
+- py_compile clean; registry JSON valid.
+- Regression test 4/4 pass (first-path-not-corrupted, all-paths-intact, matches-snapshot-parsing, empty/failure-safe).
+- Verified vs REAL drift: first item .gitignore (was gitignore); detect set == snapshot set; ticket-3820
+  session-attributable subset -> 0 -> conflict none (the Stop false-block is gone at the parse level).
+- governance-verify PASS; validator-discipline OK; baseline-drift-sentinel spec still green.
+- Cross-family consensus PASS -- receipt 00d0bf0e22583c55 (meta+mistral).
+
+## AC status
+AC1 [x] AC2 [x] AC3 [x] AC4 [x] (00d0bf0e22583c55)
+
+## Deploy
+Live deploy of hooks/scripts/git_checks.py follows merge (completes the ticket-3820 Stop-fix live activation).


### PR DESCRIPTION
Refs #3821. Root-cause of a false Stop block discovered deploying #3820.

detect_uncommitted_changes did result.stdout.strip().split(newline) — the whole-output strip ate the leading status space of the FIRST porcelain line, shifting line[3:] and corrupting that path (.gitignore -> gitignore). session_baseline.snapshot_uncommitted uses splitlines(), so Stop's baseline and uncommitted set disagreed on the first entry; should_block masked it (code-file filter) but the #3820 session-attributable conflict path leaked the 1 item -> worktree-drift -> false block.

Fix: splitlines() (existing per-line strip guard drops blanks) -> identical parsing to snapshot_uncommitted.

Verified vs real drift: first item .gitignore; detect set == snapshot set; session-attributable subset -> 0 -> conflict none. New hermetic regression test 4/4 + registry entry; governance-verify PASS; validator-discipline OK. Consensus PASS 00d0bf0e22583c55 (meta+mistral).