### PR TITLE
feat(#3013): complete HAMR tool-surface proxy (Epic #3008 Phase B)

### DIFF
--- a/.github/workflows/hamr-tool-policy.yml
+++ b/.github/workflows/hamr-tool-policy.yml
@@ -1,0 +1,35 @@
+name: hamr-tool-policy
+
+# #3013 (Epic #3008 Phase B) — regression gate for the HAMR tool-surface proxy. Runs the role-scoped
+# policy, proxy-e2e, and audit-log specs as a hard gate (harness:self-test #1893). This is the enforced
+# root that makes scripts/hamr-tool-{policy,proxy,audit}.js ENFORCED (enforcement-wiring-audit). The
+# policy is a least-privilege ROLE layer over the #2847 fleet-mcp-tools default-deny catalog; it never
+# broadens the tool surface. Pure/hermetic — Node built-ins only; no network, no gh.
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  hamr-tool-policy:
+    name: hamr-tool-policy (proxy/policy/audit self-test)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Policy self-test (allow/deny, role-scope, default fallback, AC4 compliance)
+        run: node scripts/hamr-tool-policy.spec.js
+
+      - name: Proxy e2e (approved + blocked calls, audited envelope)
+        run: node scripts/hamr-tool-proxy.spec.js
+
+      - name: Audit-log self-test (append/read/complianceRate)
+        run: node scripts/hamr-tool-audit.spec.js

--- a/inventory/harness-self-test-registry.json
+++ b/inventory/harness-self-test-registry.json
@@ -19,6 +19,9 @@
     { "name": "epic-baton-backfill-plan", "spec": "scripts/epic-baton-backfill-plan.spec.js" },
     { "name": "state-semantics", "spec": "scripts/state-semantics.spec.js" },
     { "name": "baseline-drift-sentinel", "spec": "scripts/baseline-drift-sentinel.spec.js" },
+    { "name": "hamr-tool-policy", "spec": "scripts/hamr-tool-policy.spec.js" },
+    { "name": "hamr-tool-proxy", "spec": "scripts/hamr-tool-proxy.spec.js" },
+    { "name": "hamr-tool-audit", "spec": "scripts/hamr-tool-audit.spec.js" },
     { "name": "session-baseline", "spec": "hooks/scripts/session_baseline.spec.md", "test": "hooks/scripts/session_baseline_test.py", "kind": "hook-pytest" },
     { "name": "git-checks-porcelain", "spec": "hooks/scripts/git_checks.spec.md", "test": "hooks/scripts/git_checks_test.py", "kind": "hook-pytest" }
   ]

--- a/scripts/hamr-tool-audit.spec.js
+++ b/scripts/hamr-tool-audit.spec.js
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+'use strict';
+
+// Regression spec for hamr-tool-audit (#3013 Phase B, Epic #3008). Self-executing; exit 1 on failure.
+// Hermetic: writes to a tmp log. Proves the audited-invocation-log AC (#3013 AC "audited invocation
+// logs with policy decision reason fields"): append stamps a timestamp + preserves the decision
+// fields, read tails to the limit, and complianceRate windows on ts and reports allowed-fraction.
+
+const assert = require('node:assert');
+const test = require('node:test');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { appendAudit, readAudit, complianceRate } = require('./hamr-tool-audit');
+
+let seq = 0;
+const freshLog = () => {
+  const p = path.join(os.tmpdir(), `hamr-audit-${process.pid}-${seq++}.jsonl`);
+  if (fs.existsSync(p)) fs.rmSync(p);
+  return p;
+};
+
+test('append stamps ts and preserves policy decision fields; read round-trips', () => {
+  const log = freshLog();
+  const row = appendAudit({ tool: 'github_read', role: 'collaborator', allowed: true, reason: 'ok', stage: 'policy' }, log);
+  assert.ok(typeof row.ts === 'string' && !Number.isNaN(Date.parse(row.ts)));
+  const back = readAudit(log, 10);
+  assert.strictEqual(back.length, 1);
+  assert.strictEqual(back[0].tool, 'github_read');
+  assert.strictEqual(back[0].allowed, true);
+  assert.strictEqual(back[0].reason, 'ok');
+  assert.strictEqual(back[0].stage, 'policy');
+  fs.rmSync(log);
+});
+
+test('readAudit returns [] for an absent log and tails to the limit', () => {
+  assert.deepStrictEqual(readAudit(path.join(os.tmpdir(), `nope-${process.pid}.jsonl`)), []);
+  const log = freshLog();
+  for (let i = 0; i < 5; i += 1) appendAudit({ tool: 't', role: 'r', allowed: true, reason: String(i), stage: 'policy' }, log);
+  const tail = readAudit(log, 2);
+  assert.strictEqual(tail.length, 2);
+  assert.strictEqual(tail[1].reason, '4'); // most recent last
+  fs.rmSync(log);
+});
+
+test('readAudit skips corrupt lines without throwing', () => {
+  const log = freshLog();
+  appendAudit({ tool: 'a', role: 'r', allowed: true, reason: 'ok', stage: 'policy' }, log);
+  fs.appendFileSync(log, 'this is not json\n');
+  appendAudit({ tool: 'b', role: 'r', allowed: false, reason: 'deny', stage: 'role' }, log);
+  const rows = readAudit(log, 10);
+  assert.strictEqual(rows.length, 2);
+  assert.deepStrictEqual(rows.map((r) => r.tool), ['a', 'b']);
+  fs.rmSync(log);
+});
+
+test('complianceRate windows on ts and reports allowed fraction', () => {
+  const log = freshLog();
+  // 3 allowed, 1 denied -> rate 0.75 within the window.
+  appendAudit({ tool: 'a', role: 'r', allowed: true, reason: 'ok', stage: 'policy' }, log);
+  appendAudit({ tool: 'b', role: 'r', allowed: true, reason: 'ok', stage: 'policy' }, log);
+  appendAudit({ tool: 'c', role: 'r', allowed: true, reason: 'ok', stage: 'policy' }, log);
+  appendAudit({ tool: 'd', role: 'r', allowed: false, reason: 'deny', stage: 'role' }, log);
+  const c = complianceRate(log, 0); // since epoch -> all rows in window
+  assert.strictEqual(c.total, 4);
+  assert.strictEqual(c.allowed, 3);
+  assert.ok(Math.abs(c.rate - 0.75) < 1e-9);
+  // empty window -> rate defaults to 1 (nothing denied)
+  const empty = complianceRate(log, Date.now() + 60000);
+  assert.strictEqual(empty.total, 0);
+  assert.strictEqual(empty.rate, 1);
+  fs.rmSync(log);
+});

--- a/scripts/hamr-tool-policy.js
+++ b/scripts/hamr-tool-policy.js
@@ -7,8 +7,37 @@ const { authorizeToolCall } = require('./fleet-mcp-tools');
 
 const DEFAULT_CFG = path.join(__dirname, '..', '..', 'config', 'hamr-tool-allowlist.json');
 
+// #3013 — least-privilege built-in default, layered over the #2847 default-deny catalog
+// (fleet-mcp-tools). Read tools (github_read/wiki_search/repo_map) for every offload role; the single
+// self-comment WRITE only for the two roles that post fleet advisories (collaborator analysis,
+// consultant critique) — manager/admin are read-only as a fleet identity. Grants are a strict SUBSET
+// of the existing catalog; this never broadens ALLOWED_PERMS or adds a tool. `workflows` are the
+// governed offload tool-classes used by workflowCompliance (AC4). The external allowlist at
+// DEFAULT_CFG (a deploy-time runtime override) still wins when present + valid; when it is absent /
+// unreadable / malformed, loadPolicy falls back here instead of throwing — matching the repo's
+// external-config-with-in-code-default convention (cf. authorization-profile.js).
+const DEFAULT_POLICY = Object.freeze({
+  roles: {
+    manager: ['github_read', 'wiki_search', 'repo_map'],
+    collaborator: ['github_read', 'wiki_search', 'repo_map', 'github_self_comment'],
+    admin: ['github_read', 'wiki_search', 'repo_map'],
+    consultant: ['github_read', 'wiki_search', 'repo_map', 'github_self_comment'],
+  },
+  workflows: ['github_read', 'wiki_search', 'repo_map', 'github_self_comment'],
+});
+
 function loadPolicy(cfgPath = DEFAULT_CFG) {
-  return JSON.parse(fs.readFileSync(cfgPath, 'utf8'));
+  try {
+    const ext = JSON.parse(fs.readFileSync(cfgPath, 'utf8'));
+    // A valid external override must carry a roles map; otherwise fall back to the safe default so a
+    // truncated/corrupt file cannot silently disable role-scoping.
+    if (ext && typeof ext === 'object' && ext.roles && typeof ext.roles === 'object') {
+      return { ...DEFAULT_POLICY, ...ext };
+    }
+  } catch {
+    // absent / unreadable / malformed JSON → least-privilege default (no runtime throw)
+  }
+  return DEFAULT_POLICY;
 }
 
 function roleAllows(policy, role, tool) {
@@ -35,4 +64,4 @@ function workflowCompliance(policy, role) {
   return { role, compliant: ok, total, rate: total ? ok / total : 0 };
 }
 
-module.exports = { loadPolicy, evaluateToolPolicy, roleAllows, workflowCompliance };
+module.exports = { loadPolicy, evaluateToolPolicy, roleAllows, workflowCompliance, DEFAULT_POLICY };

--- a/scripts/hamr-tool-policy.spec.js
+++ b/scripts/hamr-tool-policy.spec.js
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+'use strict';
+
+// Regression spec for hamr-tool-policy (#3013 Phase B, Epic #3008). Self-executing; exit 1 on any
+// failure. Hermetic: Node built-ins only; no network, no external config file required. Proves:
+//   (a) role-scoped allow/deny sits on TOP of the #2847 default-deny catalog (unknown/absent tool denied);
+//   (b) loadPolicy falls back to the least-privilege DEFAULT_POLICY when the external allowlist is
+//       absent / unreadable / malformed / roles-less (the live defect this ticket fixes — the old
+//       loader threw), and a VALID external override still wins;
+//   (c) least-privilege scopes: the self-comment write is granted only to collaborator/consultant;
+//   (d) workflowCompliance for the offload roles is >= 0.99 (AC4).
+
+const assert = require('node:assert');
+const test = require('node:test');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+  loadPolicy,
+  evaluateToolPolicy,
+  roleAllows,
+  workflowCompliance,
+  DEFAULT_POLICY,
+} = require('./hamr-tool-policy');
+
+const tmp = (name) => path.join(os.tmpdir(), `hamr-tool-policy-${process.pid}-${name}`);
+
+test('loadPolicy falls back to DEFAULT_POLICY when the external allowlist is absent (no throw)', () => {
+  const missing = tmp('absent.json');
+  if (fs.existsSync(missing)) fs.rmSync(missing);
+  const p = loadPolicy(missing);
+  assert.deepStrictEqual(p, DEFAULT_POLICY);
+});
+
+test('loadPolicy falls back on malformed JSON and on a roles-less object', () => {
+  const bad = tmp('bad.json');
+  fs.writeFileSync(bad, '{ not: valid json ');
+  assert.deepStrictEqual(loadPolicy(bad), DEFAULT_POLICY);
+  const rolesless = tmp('rolesless.json');
+  fs.writeFileSync(rolesless, JSON.stringify({ workflows: ['github_read'] }));
+  assert.deepStrictEqual(loadPolicy(rolesless), DEFAULT_POLICY);
+  fs.rmSync(bad); fs.rmSync(rolesless);
+});
+
+test('a VALID external override wins over the default', () => {
+  const ext = tmp('override.json');
+  fs.writeFileSync(ext, JSON.stringify({ roles: { collaborator: ['github_read'] } }));
+  const p = loadPolicy(ext);
+  assert.deepStrictEqual(p.roles.collaborator, ['github_read']);
+  // workflows not supplied by the override → filled from DEFAULT_POLICY
+  assert.deepStrictEqual(p.workflows, DEFAULT_POLICY.workflows);
+  fs.rmSync(ext);
+});
+
+test('default-deny catalog: an unknown tool is denied at the catalog stage', () => {
+  const v = evaluateToolPolicy('rm_minus_rf', {}, { role: 'collaborator' }, tmp('absent.json'));
+  assert.strictEqual(v.allowed, false);
+  assert.strictEqual(v.stage, 'catalog');
+});
+
+test('role-scope: read tools allowed for every offload role', () => {
+  for (const role of ['manager', 'collaborator', 'admin', 'consultant']) {
+    const v = evaluateToolPolicy('github_read', { kind: 'repo' }, { role }, tmp('absent.json'));
+    assert.strictEqual(v.allowed, true, `github_read should be allowed for ${role}`);
+    assert.strictEqual(v.stage, 'policy');
+  }
+});
+
+test('least-privilege: github_self_comment allowed ONLY for collaborator/consultant', () => {
+  const args = { issue: 42, body: 'fleet advisory analysis' };
+  for (const role of ['collaborator', 'consultant']) {
+    const v = evaluateToolPolicy('github_self_comment', args, { role }, tmp('absent.json'));
+    assert.strictEqual(v.allowed, true, `self-comment should be allowed for ${role}`);
+  }
+  for (const role of ['manager', 'admin']) {
+    const v = evaluateToolPolicy('github_self_comment', args, { role }, tmp('absent.json'));
+    assert.strictEqual(v.allowed, false, `self-comment must be denied for ${role}`);
+    assert.strictEqual(v.stage, 'role');
+  }
+});
+
+test('roleAllows is a strict subset of the #2847 catalog (no tool outside the catalog)', () => {
+  const catalogTools = new Set(['github_read', 'wiki_search', 'repo_map', 'github_self_comment']);
+  for (const [role, tools] of Object.entries(DEFAULT_POLICY.roles)) {
+    for (const t of tools) {
+      assert.ok(catalogTools.has(t), `role ${role} grants non-catalog tool ${t}`);
+      assert.ok(roleAllows(DEFAULT_POLICY, role, t));
+    }
+  }
+});
+
+test('AC4: workflowCompliance >= 0.99 for the offload roles', () => {
+  for (const role of ['collaborator', 'consultant']) {
+    const c = workflowCompliance(DEFAULT_POLICY, role);
+    assert.ok(c.rate >= 0.99, `offload role ${role} compliance ${c.rate} < 0.99`);
+    assert.strictEqual(c.compliant, c.total);
+  }
+});

--- a/scripts/hamr-tool-policy.spec.md
+++ b/scripts/hamr-tool-policy.spec.md
@@ -1,0 +1,44 @@
+# hamr-tool-policy — spec (#3013 · Epic #3008 Phase B)
+
+Role-scoped allow-list layered on the #2847 `fleet-mcp-tools` **default-deny** catalog, so HAMR can
+proxy a bounded set of fleet-offloaded tool workflows without ever broadening the tool surface. This is
+the G3 (zero-cost) mechanism: it lets governed review/analysis run on the free fleet under least
+privilege. Completed here from the #3818 L6 capture, which shipped the code but not its config, tests,
+or registry wiring — and left a live loader defect.
+
+## API
+- `loadPolicy(cfgPath?) → policy` — loads the external override at `../../config/hamr-tool-allowlist.json`
+  when present **and valid** (has a `roles` map); otherwise returns the built-in least-privilege
+  `DEFAULT_POLICY`. **Never throws** on an absent/unreadable/malformed/roles-less config (the defect the
+  capture shipped: the old loader `JSON.parse(readFileSync(...))` crashed because the config is not
+  shipped and the runtime path does not exist). Mirrors `authorization-profile.js`'s graceful default.
+- `DEFAULT_POLICY` — `{ roles, workflows }`. Read tools (`github_read`, `wiki_search`, `repo_map`) for
+  every offload role; the single `github_self_comment` WRITE only for `collaborator`/`consultant` (the
+  roles that post fleet advisories); `manager`/`admin` read-only as a fleet identity. Every grant is a
+  strict subset of the #2847 catalog.
+- `evaluateToolPolicy(tool, args, ctx, cfgPath?) → {allowed, stage, ...}` — two-stage decision:
+  `catalog` (the #2847 `authorizeToolCall` default-deny + arg validation) then `role` (role-scoped
+  allow-list). `stage` records where a deny happened.
+- `roleAllows(policy, role, tool) → bool`.
+- `workflowCompliance(policy, role) → {role, compliant, total, rate}` — fraction of the governed offload
+  workflow classes a role may execute (AC4).
+
+## Invariants (proved by hamr-tool-policy.spec.js + hamr-tool-proxy.spec.js + hamr-tool-audit.spec.js)
+1. **Default-deny first:** an unknown tool is denied at the `catalog` stage regardless of role.
+2. **Least privilege:** `github_self_comment` is allowed only for `collaborator`/`consultant`; denied
+   (stage `role`) for `manager`/`admin`. Role grants never include a non-catalog tool.
+3. **No-throw fallback:** absent / unreadable / malformed / roles-less config ⇒ `DEFAULT_POLICY`.
+4. **Override precedence:** a valid external config (with `roles`) wins; missing `workflows` fill from default.
+5. **AC4:** `workflowCompliance` ≥ 0.99 for the offload roles (`collaborator`, `consultant`).
+6. **Audited envelope:** the proxy emits a policy-decision audit row on allow (+ an execute row) and on
+   deny (exactly one row, broker never invoked) — `hamr-tool-audit` stamps `ts` and preserves the
+   `{tool, role, allowed, reason, stage}` decision fields.
+
+## Enforced root
+`.github/workflows/hamr-tool-policy.yml` runs all three specs as a hard gate, making
+`scripts/hamr-tool-{policy,proxy,audit}.js` ENFORCED (enforcement-wiring-audit) with sibling specs +
+registry entries (validator-discipline #1893). Pure/hermetic — Node built-ins only; no network, no gh.
+
+## Not in scope
+No change to the #2847 catalog, `ALLOWED_PERMS`, or the client-decided read + single-self-comment UAT
+boundary. This ticket adds a least-privilege ROLE layer on top; it never widens the surface.

--- a/scripts/hamr-tool-proxy.spec.js
+++ b/scripts/hamr-tool-proxy.spec.js
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+'use strict';
+
+// End-to-end regression spec for hamr-tool-proxy (#3013 Phase B, Epic #3008). Self-executing; exit 1
+// on failure. Hermetic: drives the REAL proxy -> hamr-tool-policy -> fleet-mcp-broker chain with the
+// broker's own injection seam (deps.exec) stubbed, so no gh/network is touched. Covers the #3013
+// Validation "end-to-end tests covering approved and blocked tool calls" AC: an approved read reaches
+// execution and emits a policy + execute audit row; a role-denied write and an unknown tool are both
+// stopped before the broker and emit exactly one audited deny row each.
+
+const assert = require('node:assert');
+const test = require('node:test');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { proxyToolCall, topWorkflowCompliance } = require('./hamr-tool-proxy');
+const { readAudit } = require('./hamr-tool-audit');
+
+let seq = 0;
+const freshLog = () => {
+  const p = path.join(os.tmpdir(), `hamr-proxy-audit-${process.pid}-${seq++}.jsonl`);
+  if (fs.existsSync(p)) fs.rmSync(p);
+  return p;
+};
+
+test('approved read: policy allows -> broker exec runs -> policy + execute audit rows', async () => {
+  const log = freshLog();
+  let execCalls = 0;
+  // broker ghRead does JSON.parse(exec(...)) — return a JSON string.
+  const exec = () => { execCalls += 1; return JSON.stringify({ title: 't', state: 'open' }); };
+  const out = await proxyToolCall(
+    'github_read',
+    { kind: 'issue', number: 7 },
+    { role: 'collaborator' },
+    { logPath: log, exec },
+  );
+  assert.strictEqual(out.ok, true, `expected ok, got ${JSON.stringify(out)}`);
+  assert.strictEqual(out.audited, true);
+  assert.strictEqual(execCalls, 1);
+  const rows = readAudit(log, 50);
+  assert.strictEqual(rows.length, 2, 'expect a policy row + an execute row');
+  assert.strictEqual(rows[0].stage, 'policy');
+  assert.strictEqual(rows[0].allowed, true);
+  assert.strictEqual(rows[1].stage, 'execute');
+  assert.ok(rows.every((r) => r.tool === 'github_read' && r.role === 'collaborator'));
+  fs.rmSync(log);
+});
+
+test('blocked write (role deny): broker exec NEVER runs -> single audited deny row', async () => {
+  const log = freshLog();
+  let execCalls = 0;
+  const exec = () => { execCalls += 1; return '{}'; };
+  // manager is read-only as a fleet identity -> self-comment write denied at the role stage.
+  const out = await proxyToolCall(
+    'github_self_comment',
+    { issue: 7, body: 'analysis' },
+    { role: 'manager' },
+    { logPath: log, exec },
+  );
+  assert.strictEqual(out.ok, false);
+  assert.strictEqual(out.audited, true);
+  assert.match(out.reason, /not permitted/);
+  assert.strictEqual(execCalls, 0, 'broker must not run on a denied call');
+  const rows = readAudit(log, 50);
+  assert.strictEqual(rows.length, 1);
+  assert.strictEqual(rows[0].allowed, false);
+  assert.strictEqual(rows[0].stage, 'role');
+  fs.rmSync(log);
+});
+
+test('blocked unknown tool: denied at catalog stage, no exec', async () => {
+  const log = freshLog();
+  let execCalls = 0;
+  const out = await proxyToolCall(
+    'shell_exec',
+    { cmd: 'id' },
+    { role: 'collaborator' },
+    { logPath: log, exec: () => { execCalls += 1; return '{}'; } },
+  );
+  assert.strictEqual(out.ok, false);
+  assert.strictEqual(execCalls, 0);
+  const rows = readAudit(log, 50);
+  assert.strictEqual(rows.length, 1);
+  assert.strictEqual(rows[0].stage, 'catalog');
+  fs.rmSync(log);
+});
+
+test('topWorkflowCompliance reports all four baton roles; offload role >= 0.99', () => {
+  const rows = topWorkflowCompliance();
+  const roles = rows.map((r) => r.role).sort();
+  assert.deepStrictEqual(roles, ['admin', 'collaborator', 'consultant', 'manager']);
+  const collab = rows.find((r) => r.role === 'collaborator');
+  assert.ok(collab.rate >= 0.99);
+});

--- a/wiki/work-log/ticket-3013/manager-scope.md
+++ b/wiki/work-log/ticket-3013/manager-scope.md
@@ -1,0 +1,65 @@
+# #3013 — Manager Scope: Phase B — HAMR tool-surface proxy least-privilege completion
+
+**Type:** feature/guardrail · **Area:** governance/scripts · **Priority:** P1
+**Parent:** Epic #3008 (Upgrade HAMR capability parity for fleet offload) · **Refs (bare):** Epic #3008,
+Phase-0 #3009 (research-delivered), Phase A #3012 (context envelope, done), #2847 fleet-mcp-tools
+default-deny catalog, #2791 fleet-MCP read-only tools, validator-discipline #1893, #3818 L6 capture (PR#45).
+
+## Context (drift finding)
+The #3013 deliverables — `scripts/hamr-tool-proxy.js`, `scripts/hamr-tool-policy.js`,
+`scripts/hamr-tool-audit.js` — already reached `origin/main`, but via the #3818 L6 **live-harness
+baseline capture** (commit 8d3766e / PR#45), not this child's baton cycle. The capture was faithful/
+content-only, so the ticket shipped WITHOUT satisfying its own Validation ACs and with a live defect:
+
+- `hamr-tool-policy.loadPolicy()` does `JSON.parse(fs.readFileSync(cfgPath))` against
+  `../../config/hamr-tool-allowlist.json`, a runtime path that does not exist and is not shipped →
+  **every call throws at runtime** (unlike sibling `authorization-profile.js`, which falls back to a
+  built-in default when its external config is absent). The role-scoped allow-list therefore never
+  enforces anything — it hard-crashes.
+- No policy/proxy/audit regression specs exist (the #3013 Validation section requires unit + e2e tests).
+- No `harness-self-test-registry` entry (validator-discipline #1893).
+
+## Objective
+Complete #3013 to its ACs by (a) fixing the loader defect with a **built-in least-privilege
+`DEFAULT_POLICY`** (absent/malformed external override → safe default, matching the repo's
+external-config-with-in-code-default convention), and (b) shipping the missing regression coverage +
+registry entry + CI enforcement so the tool-surface proxy is governed and tested.
+
+## Design
+`scripts/hamr-tool-policy.js`:
+- Add `DEFAULT_POLICY`: least-privilege role→tool grants over the #2847 default-deny catalog. Read tools
+  (`github_read`, `wiki_search`, `repo_map`) for every offload role; the single `github_self_comment`
+  write ONLY for the two roles that post fleet advisories (collaborator, consultant). manager/admin
+  read-only as a fleet identity. `workflows` = the governed offload tool-classes.
+- `loadPolicy(cfgPath)`: try the external override; on absent/unreadable/malformed/roles-less config
+  fall back to `DEFAULT_POLICY` (no throw). A valid external config still wins (behavior preserved).
+
+Regression coverage (self-executing `node:test` specs, hermetic, exit 1 on failure):
+- `scripts/hamr-tool-policy.spec.js` — catalog default-deny passthrough, role-scope allow/deny,
+  default-fallback on missing/malformed config, external-override precedence, workflowCompliance ≥0.99
+  for offload roles.
+- `scripts/hamr-tool-proxy.spec.js` — e2e approved call (policy→broker→audited envelope) and blocked
+  call (policy deny → no broker invocation, audited), audit-trail assertions (injected tmp log + broker).
+- `scripts/hamr-tool-audit.spec.js` — append/read round-trip, read-limit tail, complianceRate window.
+
+Wiring: `scripts/hamr-tool-policy.spec.md` doc, one `harness-self-test-registry` entry (hamr-tool-policy),
+CI workflow `.github/workflows/hamr-tool-policy.yml` running all three specs as a hard gate (the enforced
+root that makes the scripts ENFORCED per enforcement-wiring-audit).
+
+## Acceptance criteria (maps to #3013)
+- [ ] AC1 capability allow-list + deny-list enforcement — default-deny catalog (#2847) + role-scoped
+      allow-list with a working least-privilege default; unit-tested.
+- [ ] AC2 least-privilege capability scopes mapped to role/task classes (manager/collaborator/admin/consultant).
+- [ ] AC3 audited invocation logs with policy decision reason fields (proxy e2e proves audit rows on allow+deny).
+- [ ] AC4 offload workflow classes executable with policy compliance >99% for offload roles (workflowCompliance test).
+- [ ] AC5 sibling specs + registry entry + CI enforcement (validator-discipline #1893; enforcement-wiring-audit ENFORCED).
+- [ ] AC6 free ≥2-family cross-model consensus; receipt recorded.
+
+## Rails
+Reversible, autonomous per operator directive (feature branch, restrictive least-privilege default =
+hardening not weakening, no protected-main direct write). No carve-out. Does not broaden the #2847 tool
+catalog or the ALLOWED_PERMS boundary — role grants are a strict subset of the existing default-deny catalog.
+
+Signed-by: Orla Mason
+Team&Model: claude-code:opus@local
+Role: manager

--- a/wiki/work-log/ticket-3013/validation.md
+++ b/wiki/work-log/ticket-3013/validation.md
@@ -1,0 +1,37 @@
+# #3013 — Validation (HAMR tool-surface proxy least-privilege completion, Phase B)
+
+**Branch:** feat/3013-hamr-tool-proxy · **Base:** origin/main · **Parent:** Epic #3008
+**Files:** scripts/hamr-tool-policy.js (loader fix + DEFAULT_POLICY), scripts/hamr-tool-policy.spec.js,
+scripts/hamr-tool-proxy.spec.js, scripts/hamr-tool-audit.spec.js, scripts/hamr-tool-policy.spec.md,
+inventory/harness-self-test-registry.json (+3), .github/workflows/hamr-tool-policy.yml.
+
+## Result
+- node --check clean (all js). Registry JSON valid.
+- Specs: **16/16 pass** — hamr-tool-policy 8/8, hamr-tool-proxy 4/4, hamr-tool-audit 4/4. Hermetic
+  (Node built-ins only; no gh/network; tmp logs).
+- Live defect fixed: `loadPolicy()` no longer throws on the absent external config — falls back to the
+  least-privilege `DEFAULT_POLICY` (proved by the absent/malformed/roles-less tests). A valid external
+  override still wins.
+- Least-privilege proved: `github_self_comment` allowed only for collaborator/consultant; denied
+  (stage `role`) for manager/admin. All role grants are a strict subset of the #2847 catalog.
+- AC4: workflowCompliance ≥ 0.99 for offload roles (collaborator/consultant = 1.0).
+- Audited envelope: proxy emits policy+execute rows on allow, one deny row on block (broker never
+  invoked); audit stamps ts + preserves decision fields.
+- validator-discipline OK (modified validator ships sibling spec + registry entry).
+- enforcement-wiring-audit: hamr-tool-policy / hamr-tool-proxy / hamr-tool-audit all **ENFORCED** (new
+  workflow root → spec → require chain).
+- Content-only changeset (only ticket-3013 files + the shared registry line).
+- Cross-family consensus **PASS** — receipt `9796ff0577d1964f` (meta[groq] + mistral, both PASS; $0 free-cloud).
+
+## AC status (maps to #3013)
+- AC1 [x] allow-list + deny-list enforcement (default-deny catalog + working least-privilege role layer).
+- AC2 [x] least-privilege scopes mapped to manager/collaborator/admin/consultant.
+- AC3 [x] audited invocation logs with policy-decision reason fields (proxy e2e + audit spec).
+- AC4 [x] offload workflow classes executable with compliance >99% for offload roles.
+- AC5 [x] sibling specs + registry entries + CI enforced root; validator-discipline OK.
+- AC6 [x] free ≥2-family cross-model consensus PASS — 9796ff0577d1964f.
+
+## Drift/scope note
+Completes the #3013 code that shipped via the #3818 L6 baseline capture (PR#45) without its config,
+tests, or registry wiring. No change to the #2847 fleet-mcp-tools catalog, ALLOWED_PERMS, or the
+client-decided read + single-self-comment UAT boundary — least-privilege ROLE layer only (hardening).


### PR DESCRIPTION
## #3013 Phase B — HAMR tool-surface proxy (Epic 3008)

**Reconciliation + gap-remediation.** The #3013 deliverables (hamr-tool-proxy/policy/audit) reached main via the #3818 L6 live-harness baseline capture (PR#45) — faithful/content-only, so they shipped WITHOUT their config, tests, or registry wiring, and with a live loader defect.

### Fixed
- `hamr-tool-policy.loadPolicy()` did `JSON.parse(readFileSync(../../config/hamr-tool-allowlist.json))` — a runtime path that is never shipped and does not exist → **every call threw**, so role-scoping crashed instead of enforcing. Added a built-in least-privilege `DEFAULT_POLICY` and graceful fallback (absent/unreadable/malformed/roles-less → default, never throws), matching the repo's `authorization-profile.js` convention. A valid external override still wins.

### Least privilege (strict subset of the #2847 default-deny catalog)
- Read tools (`github_read`/`wiki_search`/`repo_map`) for every offload role; `github_self_comment` write only for collaborator/consultant; manager/admin read-only as a fleet identity. No change to the #2847 catalog, `ALLOWED_PERMS`, or the read + single-self-comment UAT boundary.

### Coverage
- 3 hermetic self-executing specs — **16/16 pass** (policy allow/deny+role-scope+fallback+AC4 compliance; proxy e2e approved+blocked audited envelope; audit append/read/complianceRate).
- Registry +3 entries; new CI workflow (enforced root); all 3 scripts now **ENFORCED** (enforcement-wiring-audit); validator-discipline OK.

### AC status
AC1 [x] AC2 [x] AC3 [x] AC4 [x] AC5 [x] AC6 [x] — cross-family consensus **PASS**, receipt `9796ff0577d1964f` (meta+mistral, $0 free-cloud).

Parent: Epic #3008. Reversible feature branch; least-privilege hardening only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)