### PR TITLE
fix(#3823): baseline-cutover mode-awareness + origin-ahead (truthful dry-run)

### DIFF
--- a/scripts/baseline-cutover.js
+++ b/scripts/baseline-cutover.js
@@ -1,27 +1,40 @@
 #!/usr/bin/env node
 'use strict';
 /*
- * baseline-cutover (#3822) — Mode C (CUTOVER) tooling of the ratified baseline-drift reconciler
- * (design receipt 3355d17ac42b51ae; ticket-3801 AC4 / ticket-3818 closeout child).
+ * baseline-cutover (#3822, mode-aware #3823) — Mode C (CUTOVER) tooling of the ratified baseline-drift
+ * reconciler (design receipt 3355d17ac42b51ae; #3801 AC4 / #3818 closeout child).
  *
- * Goal: make the canonical checkout's `git status` clean (ticket-3801 AC4) by reconciling its tracked
- * baseline to the ALREADY-byte-identical origin/main content — under a hard BYTE-IDENTITY INVARIANT
- * (a file's working-tree bytes must equal origin/main before it is considered cut-over-safe) and
- * blue-green reversibility.
+ * Makes the canonical checkout's `git status` clean (#3801 AC4) by reconciling its tracked baseline to
+ * origin/main, under a byte-identity invariant and blue-green reversibility.
  *
- * SAFETY POSTURE: this tool NEVER mutates the live checkout. It (a) computes readiness, (b) enforces
- * the byte-identity invariant, (c) reports blockers (documented holds / genuine divergence), and
- * (d) emits the exact vetted re-park + rollback git recipe for the GATED operator step (the live flip
- * is a retained carve-out: irreversible/security). `verifyClean` checks the post-cutover state. No
- * function here runs `git checkout/reset/clean` — the irreversible command is emitted as text, run by a
- * human under go/no-go, so the tool cannot brick the running-guard checkout.
+ * TRUTHFULNESS (#3823): readiness is computed the way `git reset --mixed origin/main` actually resolves,
+ * via a TEMP INDEX (never the real index/HEAD): read-tree origin/main into a throwaway index, then
+ * `git diff --raw` (working tree vs that index) + `ls-files --others`. This catches what a content-only
+ * `cmp` missed during the first cutover attempt: (a) MODE drift (canonical working tree is wholesale
+ * 100755 vs origin's 100644) and (b) ORIGIN-AHEAD files (origin tracks paths the working tree lacks,
+ * because origin advanced). The prior content-only check reported a false "ready".
+ *
+ * SAFETY POSTURE: still NEVER mutates the live checkout. No git checkout/reset/clean on the real repo;
+ * the temp index lives in os.tmpdir(). The irreversible re-park is emitted as a strings-only recipe for
+ * a gated human go/no-go with guard self-tests as health gate + instant rollback.
  */
 
 const { execFileSync } = require('child_process');
+const os = require('os');
+const path = require('path');
+const fs = require('fs');
 
-function git(root, args, { allowFail = false } = {}) {
+let _tmpCounter = 0;
+
+function git(root, args, { allowFail = false, env = null, input = null } = {}) {
   try {
-    return execFileSync('git', args, { cwd: root, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+    return execFileSync('git', args, {
+      cwd: root, encoding: 'utf8',
+      stdio: [input == null ? 'ignore' : 'pipe', 'pipe', 'ignore'],
+      env: env ? { ...process.env, ...env } : process.env,
+      input: input == null ? undefined : input,
+      maxBuffer: 64 * 1024 * 1024,
+    });
   } catch (e) {
     if (allowFail) return null;
     throw e;
@@ -29,59 +42,114 @@ function git(root, args, { allowFail = false } = {}) {
 }
 
 /**
- * Pure classifier — the unit-tested core. Given per-path facts, bucket into cut-over classes.
- * @param {{path:string, existsOnOrigin:boolean, workingEqualsOrigin:boolean, hold?:boolean}[]} entries
- * @returns {{safe:string[], blockers:{path:string,reason:string}[], holds:string[], absent:string[]}}
+ * Pure classifier — the unit-tested core. Buckets richer per-path facts (each carries a `kind`).
+ * @param {{path:string, kind:'safe'|'modeDrift'|'content'|'originAhead'|'untracked', hold?:boolean}[]} entries
+ * @returns {{safe:string[], modeDrift:string[], contentBlockers:{path:string,reason:string}[],
+ *            originAhead:string[], untracked:string[], holds:string[]}}
  */
 function classifyCutover(entries) {
-  const safe = [], blockers = [], holds = [], absent = [];
+  const safe = [], modeDrift = [], contentBlockers = [], originAhead = [], untracked = [], holds = [];
   for (const e of entries || []) {
     const p = String(e.path);
-    if (e.hold) { holds.push(p); continue; }                 // documented hold: expected to remain dirty
-    if (!e.existsOnOrigin) { absent.push(p); continue; }     // not yet captured to origin/main
-    if (e.workingEqualsOrigin) { safe.push(p); }             // byte-identical -> safe to cut over
-    else { blockers.push({ path: p, reason: 'working bytes differ from origin/main (uncaptured drift or undocumented hold)' }); }
+    if (e.hold) { holds.push(p); continue; }               // documented hold: expected to remain dirty
+    switch (e.kind) {
+      case 'safe': safe.push(p); break;                    // content + mode identical to origin
+      case 'modeDrift': modeDrift.push(p); break;          // content identical, mode differs (recipe normalizes)
+      case 'originAhead': originAhead.push(p); break;      // origin tracks it, working lacks it (recipe restores)
+      case 'untracked': untracked.push(p); break;          // working-only (feat/3026 deliverable or new drift)
+      case 'content':
+      default:
+        contentBlockers.push({ path: p, reason: 'working content differs from origin/main (uncaptured drift or undocumented hold)' });
+    }
   }
-  return { safe, blockers, holds, absent };
+  return { safe, modeDrift, contentBlockers, originAhead, untracked, holds };
 }
 
 /**
- * Best-effort per-path facts for the canonical checkout at `root`. For each drifted path, compare its
- * working-tree bytes to `origin/main:<path>`. Returns [] on a clean tree or failure (CI-safe).
- * @param {string[]} [holdPaths] documented holds (kept dirty by design; e.g. L7 governance-verify.js)
+ * TRUE cutover divergence at `root`, computed against origin/main via a throwaway index — the same delta
+ * `git reset --mixed origin/main` would produce. Returns [] on failure (CI-safe). Never mutates the repo.
+ * @param {string[]} [holdPaths] documented holds (kept dirty by design)
+ * @returns {{path:string, kind:string, hold:boolean}[]}
  */
-function collectEntries(root, holdPaths) {
+function divergence(root, holdPaths) {
   const holds = new Set(holdPaths || []);
-  const status = git(root, ['status', '--porcelain', '-uall'], { allowFail: true });
-  if (!status) return [];
-  const paths = status.split('\n').map((l) => l.slice(3)).filter((p) => p && p.trim());
-  const fs = require('fs');
-  const path = require('path');
-  return paths.map((p) => {
-    const originBlob = git(root, ['cat-file', '-p', `origin/main:${p}`], { allowFail: true });
-    const existsOnOrigin = originBlob !== null;
-    let workingEqualsOrigin = false;
-    if (existsOnOrigin) {
-      try {
-        const working = fs.readFileSync(path.join(root, p));
-        workingEqualsOrigin = Buffer.from(originBlob, 'utf8').equals(working)
-          || working.toString('utf8') === originBlob; // tolerate text newline normalization
-      } catch (_) { workingEqualsOrigin = false; }
+  // Resolve target ref; bail cleanly if origin/main is absent (fresh clone / CI without remote).
+  const target = git(root, ['rev-parse', '--verify', '--quiet', 'origin/main'], { allowFail: true });
+  if (!target) return [];
+  const tmpIndex = path.join(os.tmpdir(), `cutover-idx-${process.pid}-${_tmpCounter++}`);
+  try {
+    // Populate the temp index with origin/main's tree (does NOT touch the real index/HEAD/working tree).
+    if (git(root, ['read-tree', 'origin/main'], { allowFail: true, env: { GIT_INDEX_FILE: tmpIndex } }) === null) return [];
+    const entries = [];
+    // `git diff --raw` (temp index == origin/main  vs  working tree): one line per changed path.
+    // Format: :<oldmode> <newmode> <oldsha> <newsha> <status>\t<path>
+    //   oldmode/oldsha = origin/main ; newmode/newsha = working tree (000000/0000000 when deleted).
+    // `--abbrev=40` forces FULL origin blob shas (raw abbreviates to 7 by default), so they compare
+    // equal to the 40-char `hash-object` output of the working copies below.
+    const raw = git(root, ['diff', '--raw', '--no-color', '-z', '--abbrev=40'], { allowFail: true, env: { GIT_INDEX_FILE: tmpIndex } }) || '';
+    const toks = raw.split('\0');
+    // First pass: parse raw meta. NOTE `git diff --raw` reports the WORKING side's sha as all-zeros (it
+    // doesn't hash the working tree), so mode-vs-content CANNOT be decided from the raw shas. We record
+    // origin's blob sha (oldsha) and defer content classification to a batched hash-object below.
+    const changed = []; // {path, oldsha, modeChanged, deleted}
+    for (let i = 0; i < toks.length; i++) {
+      const meta = toks[i];
+      if (!meta.startsWith(':')) continue;
+      const p = toks[++i];
+      if (!p) continue;
+      const [oldmode, newmode, oldsha, , status] = meta.slice(1).split(/\s+/);
+      const deleted = status === 'D' || newmode === '000000';
+      changed.push({ path: p, oldsha, modeChanged: oldmode !== newmode, deleted });
     }
-    return { path: p, existsOnOrigin, workingEqualsOrigin, hold: holds.has(p) };
-  });
+    // Batch-hash the working-tree copies of the non-deleted changed files, then compare to origin's blob:
+    // equal blob => MODE-ONLY drift; unequal => real CONTENT divergence.
+    const toHash = changed.filter((e) => !e.deleted).map((e) => e.path);
+    let workingSha = {};
+    if (toHash.length) {
+      const out = git(root, ['hash-object', '--stdin-paths'], { allowFail: true, input: toHash.join('\n') + '\n' }) || '';
+      const shas = out.split('\n').filter(Boolean);
+      toHash.forEach((p, idx) => { workingSha[p] = shas[idx]; });
+    }
+    for (const e of changed) {
+      let kind;
+      if (e.deleted) kind = 'originAhead';                                  // origin has it, working lacks it
+      else if (workingSha[e.path] === e.oldsha) kind = 'modeDrift';         // blob equal => exec-bit only
+      else kind = 'content';                                               // real content divergence
+      entries.push({ path: e.path, kind, hold: holds.has(e.path) });
+    }
+    // Working-tree files not present in origin/main's tree (untracked relative to the temp index).
+    const others = git(root, ['ls-files', '--others', '--exclude-standard', '-z'], { allowFail: true, env: { GIT_INDEX_FILE: tmpIndex } }) || '';
+    for (const p of others.split('\0')) {
+      if (p && p.trim()) entries.push({ path: p, kind: 'untracked', hold: holds.has(p) });
+    }
+    return entries;
+  } finally {
+    try { fs.unlinkSync(tmpIndex); } catch (_) { /* best-effort temp cleanup */ }
+  }
 }
 
-/** Readiness plan. `ready` iff no blockers (holds are allowed to remain). */
+/**
+ * Readiness plan against origin/main. `ready` (content-safe to proceed) iff there are no undocumented
+ * CONTENT blockers. modeDrift + originAhead are recipe-resolvable but REPORTED so the dry-run is honest
+ * about scale (the #3823 fix: the old plan hid these behind a content-only "ready"). `fullyClean` iff
+ * the working tree already equals origin/main entirely (only holds may remain).
+ */
 function plan(root, opts) {
-  const c = classifyCutover(collectEntries(root, (opts && opts.holds) || []));
+  const c = classifyCutover(divergence(root, (opts && opts.holds) || []));
+  const ready = c.contentBlockers.length === 0;
   return {
-    ready: c.blockers.length === 0,
+    ready,
+    fullyClean: ready && c.modeDrift.length === 0 && c.originAhead.length === 0 && c.untracked.length === 0,
     safeCount: c.safe.length,
-    blockers: c.blockers,
+    modeDriftCount: c.modeDrift.length,
+    originAheadCount: c.originAhead.length,
+    untrackedCount: c.untracked.length,
+    contentBlockers: c.contentBlockers,
     holds: c.holds,
-    absent: c.absent,
-    invariantHeld: c.blockers.length === 0 && c.absent.length === 0,
+    // Scale disclosure: what the recipe WILL touch to reach a clean status.
+    willNormalizeModes: c.modeDrift.length,
+    willRestoreFromOrigin: c.originAhead.length,
+    willLeaveUntracked: c.untracked.length,
   };
 }
 
@@ -89,25 +157,27 @@ function plan(root, opts) {
 function recipe(root, targetRef = 'origin/main') {
   return {
     preconditions: [
-      `node scripts/baseline-cutover.js --dry-run   # must report ready (0 blockers)`,
+      `node scripts/baseline-cutover.js --dry-run   # 0 contentBlockers; review mode/origin-ahead scale`,
+      `# freeze parallel merges to ${targetRef} first — it must not advance during the flip (moving target).`,
       `node scripts/governance-verify.js && node scripts/validator-discipline.js --base ${targetRef}`,
     ],
-    // Re-park keeps working-tree bytes (they already match ${targetRef}); it moves the tracked baseline
-    // so status becomes clean. Run under go/no-go; the guard self-tests are the health gate.
     reparkRecipe: [
       `# 1. snapshot rollback ref (current HEAD of the canonical checkout)`,
       `PRIOR=$(git -C ${root} rev-parse HEAD)`,
-      `# 2. move the tracked baseline to ${targetRef} WITHOUT touching working bytes (soft), then let`,
-      `#    the now-tracked captured files read as clean:`,
-      `git -C ${root} switch --force-create parked-baseline ${targetRef}   # or: git checkout ${targetRef}`,
-      `# 3. HEALTH GATE — running-guard self-tests must pass post-cutover:`,
+      `# 2. preserve feat/3026 by parking on a NEW compliant-named branch at the same commit, then move`,
+      `#    the tracked baseline to ${targetRef} WITHOUT touching working bytes (mixed = index-only):`,
+      `git -C ${root} switch -c feat/3801-canonical-parked && git -C ${root} reset --mixed ${targetRef}`,
+      `# 3. reconcile the working tree to ${targetRef}: normalizes the 100755->100644 mode drift, restores`,
+      `#    origin-ahead files, and adopts origin content (byte-identical files are unchanged):`,
+      `git -C ${root} checkout -- .`,
+      `# 4. HEALTH GATE — running-guard self-tests must pass post-cutover:`,
       `node ${root}/scripts/governance-verify.js && node ${root}/hooks/scripts/session_baseline_test.py`,
       `node ${root}/scripts/baseline-cutover.js --verify   # status clean modulo documented holds`,
     ],
     rollbackRecipe: [
       `# blue-green instant rollback (never force-push main):`,
-      `git -C ${root} switch --force-create feat/3026-zero-miss-guardrails "$PRIOR"   # restore prior HEAD`,
-      `# working-tree bytes are unchanged throughout (byte-identity invariant), so no content is lost.`,
+      `git -C ${root} reset --mixed "$PRIOR" && git -C ${root} switch feat/3026-zero-miss-guardrails`,
+      `# reset --mixed writes no working bytes; if step 3 ran, restore drift from the pre-cutover backup.`,
     ],
   };
 }
@@ -125,39 +195,45 @@ function verifyClean(root, opts) {
 function selfTest() {
   const assert = (c, m) => { if (!c) throw new Error('SELFTEST FAIL: ' + m); };
   const c = classifyCutover([
-    { path: 'a.js', existsOnOrigin: true, workingEqualsOrigin: true },
-    { path: 'b.js', existsOnOrigin: true, workingEqualsOrigin: false },
-    { path: 'held.js', existsOnOrigin: true, workingEqualsOrigin: false, hold: true },
-    { path: 'new.js', existsOnOrigin: false, workingEqualsOrigin: false },
+    { path: 'same.js', kind: 'safe' },
+    { path: 'mode.js', kind: 'modeDrift' },
+    { path: 'content.js', kind: 'content' },
+    { path: 'ahead.js', kind: 'originAhead' },
+    { path: 'extra.js', kind: 'untracked' },
+    { path: 'held.js', kind: 'content', hold: true },
   ]);
-  assert(c.safe.length === 1 && c.safe[0] === 'a.js', 'byte-identical -> safe');
-  assert(c.blockers.length === 1 && c.blockers[0].path === 'b.js', 'divergent -> blocker');
-  assert(c.holds.length === 1 && c.holds[0] === 'held.js', 'documented hold bucketed');
-  assert(c.absent.length === 1 && c.absent[0] === 'new.js', 'uncaptured -> absent');
+  assert(c.safe.length === 1 && c.safe[0] === 'same.js', 'safe bucket');
+  assert(c.modeDrift.length === 1 && c.modeDrift[0] === 'mode.js', 'modeDrift bucket (NEW #3823)');
+  assert(c.contentBlockers.length === 1 && c.contentBlockers[0].path === 'content.js', 'content blocker');
+  assert(c.originAhead.length === 1 && c.originAhead[0] === 'ahead.js', 'originAhead bucket (NEW #3823)');
+  assert(c.untracked.length === 1 && c.untracked[0] === 'extra.js', 'untracked bucket');
+  assert(c.holds.length === 1 && c.holds[0] === 'held.js', 'documented hold outranks content');
 
-  // empty => ready, invariant held
-  const ce = classifyCutover([]);
-  assert(ce.safe.length === 0 && ce.blockers.length === 0, 'empty clean');
+  // a run with ONLY modeDrift/originAhead is content-ready but NOT fullyClean
+  const c2 = classifyCutover([{ path: 'm.js', kind: 'modeDrift' }, { path: 'a.js', kind: 'originAhead' }]);
+  assert(c2.contentBlockers.length === 0, 'mode/origin-ahead are not content blockers');
+  assert(c2.modeDrift.length === 1 && c2.originAhead.length === 1, 'reported for scale disclosure');
 
-  // recipe is strings-only and mentions the invariant + rollback
+  // recipe strings mention mode-normalization + origin freeze + rollback (the #3823 additions)
   const r = recipe('/x');
-  assert(Array.isArray(r.reparkRecipe) && Array.isArray(r.rollbackRecipe), 'recipe shape');
-  assert(r.reparkRecipe.join(' ').includes('HEALTH GATE'), 'recipe includes health gate');
-  assert(r.rollbackRecipe.join(' ').includes('rollback') || r.rollbackRecipe.join(' ').includes('restore'),
-    'recipe includes rollback');
+  const joined = r.preconditions.concat(r.reparkRecipe, r.rollbackRecipe).join('\n');
+  assert(/checkout -- \./.test(joined), 'recipe normalizes modes / adopts origin via checkout');
+  assert(/moving target|must not advance|freeze/i.test(joined), 'recipe warns about the moving target');
+  assert(/rollback|restore/i.test(joined), 'recipe includes rollback');
+  assert(!/execFileSync|spawn/.test(joined), 'recipe carries no executable calls');
 
-  // plan on a clean/CI root is ready
+  // plan on a clean/CI root is content-ready, exit-0 shape
   const p = plan(process.cwd(), { holds: [] });
-  assert(typeof p.ready === 'boolean' && Array.isArray(p.blockers), 'plan shape');
+  assert(typeof p.ready === 'boolean' && Array.isArray(p.contentBlockers), 'plan shape');
+  assert(typeof p.modeDriftCount === 'number' && typeof p.originAheadCount === 'number', 'plan discloses scale');
   return true;
 }
 
-module.exports = { classifyCutover, collectEntries, plan, recipe, verifyClean, selfTest };
+module.exports = { classifyCutover, divergence, plan, recipe, verifyClean, selfTest };
 
 if (require.main === module) {
   const args = process.argv.slice(2);
-  const root = process.env.CUTOVER_ROOT ? require('path').resolve(process.env.CUTOVER_ROOT) : process.cwd();
-  // Documented holds (kept dirty by design). Extend via CUTOVER_HOLDS (comma-sep) — e.g. L7's hold.
+  const root = process.env.CUTOVER_ROOT ? path.resolve(process.env.CUTOVER_ROOT) : process.cwd();
   const holds = (process.env.CUTOVER_HOLDS || '').split(',').map((s) => s.trim()).filter(Boolean);
 
   if (args.includes('--self-test')) {
@@ -169,21 +245,22 @@ if (require.main === module) {
     console.log(`baseline-cutover verify: ${v.clean ? 'CLEAN' : 'DIRTY'}`
       + (v.dirty && v.dirty.length ? ` — ${v.dirty.length} residual: ${v.dirty.slice(0, 10).join(', ')}` : '')
       + (v.heldOut && v.heldOut.length ? ` (held-out: ${v.heldOut.join(', ')})` : ''));
-    process.exit(0); // advisory
-  }
-  if (args.includes('--recipe')) {
-    console.log(JSON.stringify(recipe(root), null, 2));
     process.exit(0);
   }
-  // Default: DRY-RUN readiness (never mutates). ALWAYS exit 0 (advisory/report).
+  if (args.includes('--recipe')) { console.log(JSON.stringify(recipe(root), null, 2)); process.exit(0); }
+
+  // Default: TRUTHFUL DRY-RUN (never mutates). ALWAYS exit 0 (advisory/report).
   const p = plan(root, { holds });
-  console.log(`baseline-cutover DRY-RUN (advisory; NEVER mutates): ready=${p.ready} `
-    + `safe=${p.safeCount} blockers=${p.blockers.length} holds=${p.holds.length} absent=${p.absent.length}`);
-  if (p.blockers.length) {
-    console.log('  BLOCKERS (must capture to origin/main or document as holds before live cutover):');
-    p.blockers.slice(0, 20).forEach((b) => console.log(`   ✗ ${b.path} — ${b.reason}`));
+  console.log(`baseline-cutover DRY-RUN (advisory; NEVER mutates): ready=${p.ready} fullyClean=${p.fullyClean} `
+    + `safe=${p.safeCount} contentBlockers=${p.contentBlockers.length} holds=${p.holds.length}`);
+  console.log(`  cutover will: normalize ${p.willNormalizeModes} modes (100755->100644), `
+    + `restore ${p.willRestoreFromOrigin} origin-ahead files, leave ${p.willLeaveUntracked} untracked residuals.`);
+  if (p.contentBlockers.length) {
+    console.log('  CONTENT BLOCKERS (capture to origin/main or document as holds before cutover):');
+    p.contentBlockers.slice(0, 20).forEach((b) => console.log(`   ✗ ${b.path} — ${b.reason}`));
   }
   if (p.holds.length) console.log(`  holds (kept dirty by design): ${p.holds.join(', ')}`);
-  if (p.ready) console.log('  READY — the live re-park is a GATED carve-out; emit the vetted recipe with --recipe.');
+  if (p.ready && !p.fullyClean) console.log('  content-READY, but NOT a trivial flip — the recipe touches the mode/origin-ahead files above. Freeze parallel merges, then --recipe.');
+  if (p.fullyClean) console.log('  FULLY CLEAN — working tree already equals origin/main; re-park is a no-op cleanup.');
   process.exit(0);
 }

--- a/scripts/baseline-cutover.spec.js
+++ b/scripts/baseline-cutover.spec.js
@@ -1,10 +1,9 @@
 #!/usr/bin/env node
 'use strict';
 /*
- * Regression spec for baseline-cutover (#3822) — hard gate (harness:self-test ticket-1893).
- * Node built-ins only; hermetic (no network, no gh, no live checkout mutation). Exits non-zero on any
- * failure. The module never mutates a checkout, so these tests exercise the pure classifier, the
- * strings-only recipe, and the CI-safe plan/verify paths.
+ * Regression spec for baseline-cutover (#3822, mode-aware #3823) — hard gate (harness:self-test #1893).
+ * Node built-ins only; hermetic (no network, no gh, no live-checkout mutation). Exits non-zero on any
+ * failure. The module never mutates a checkout; the temp-index divergence oracle uses os.tmpdir().
  */
 const assert = require('assert');
 const c = require('./baseline-cutover');
@@ -14,44 +13,60 @@ const it = (name, fn) => { fn(); n += 1; console.log(`  PASS ${name}`); };
 
 it('module selfTest() passes', () => { assert.strictEqual(c.selfTest(), true); });
 
-it('classifyCutover buckets safe / blocker / hold / absent', () => {
+it('classifyCutover buckets safe / modeDrift / content / originAhead / untracked / hold (#3823)', () => {
   const r = c.classifyCutover([
-    { path: 'x.js', existsOnOrigin: true, workingEqualsOrigin: true },
-    { path: 'y.js', existsOnOrigin: true, workingEqualsOrigin: false },
-    { path: 'h.js', existsOnOrigin: true, workingEqualsOrigin: false, hold: true },
-    { path: 'n.js', existsOnOrigin: false, workingEqualsOrigin: false },
+    { path: 'a.js', kind: 'safe' },
+    { path: 'm.js', kind: 'modeDrift' },
+    { path: 'x.js', kind: 'content' },
+    { path: 'o.js', kind: 'originAhead' },
+    { path: 'u.js', kind: 'untracked' },
+    { path: 'h.js', kind: 'content', hold: true },
   ]);
-  assert.deepStrictEqual(r.safe, ['x.js']);
-  assert.deepStrictEqual(r.blockers.map((b) => b.path), ['y.js']);
+  assert.deepStrictEqual(r.safe, ['a.js']);
+  assert.deepStrictEqual(r.modeDrift, ['m.js']);
+  assert.deepStrictEqual(r.contentBlockers.map((b) => b.path), ['x.js']);
+  assert.deepStrictEqual(r.originAhead, ['o.js']);
+  assert.deepStrictEqual(r.untracked, ['u.js']);
   assert.deepStrictEqual(r.holds, ['h.js']);
-  assert.deepStrictEqual(r.absent, ['n.js']);
 });
 
-it('a hold is never a blocker (kept dirty by design)', () => {
-  const r = c.classifyCutover([{ path: 'gv.js', existsOnOrigin: true, workingEqualsOrigin: false, hold: true }]);
-  assert.strictEqual(r.blockers.length, 0);
-  assert.deepStrictEqual(r.holds, ['gv.js']);
+it('mode drift and origin-ahead are NOT content blockers (the #3823 truthfulness fix)', () => {
+  const r = c.classifyCutover([{ path: 'm.js', kind: 'modeDrift' }, { path: 'o.js', kind: 'originAhead' }]);
+  assert.strictEqual(r.contentBlockers.length, 0);
+  assert.strictEqual(r.modeDrift.length, 1);
+  assert.strictEqual(r.originAhead.length, 1);
 });
 
-it('recipe is strings-only and contains invariant/health-gate/rollback (never executes git)', () => {
+it('an undocumented content divergence IS a blocker; a documented hold is not', () => {
+  const r = c.classifyCutover([
+    { path: 'drift.js', kind: 'content' },
+    { path: 'held.js', kind: 'content', hold: true },
+  ]);
+  assert.deepStrictEqual(r.contentBlockers.map((b) => b.path), ['drift.js']);
+  assert.deepStrictEqual(r.holds, ['held.js']);
+});
+
+it('recipe (strings-only) normalizes modes, warns on moving target, includes rollback, runs no git', () => {
   const r = c.recipe('/repo');
-  assert.ok(Array.isArray(r.reparkRecipe) && r.reparkRecipe.every((s) => typeof s === 'string'));
-  const joined = (r.reparkRecipe.concat(r.rollbackRecipe)).join('\n');
-  assert.ok(/HEALTH GATE/.test(joined), 'health gate present');
+  const joined = r.preconditions.concat(r.reparkRecipe, r.rollbackRecipe).join('\n');
+  assert.ok(/checkout -- \./.test(joined), 'mode-normalize / adopt-origin step present');
+  assert.ok(/moving target|must not advance|freeze/i.test(joined), 'moving-target warning present');
   assert.ok(/rollback|restore/i.test(joined), 'rollback present');
-  assert.ok(!/execFileSync|spawn/.test(joined), 'recipe carries no executable calls');
+  assert.ok(!/execFileSync|spawn/.test(joined), 'no executable calls embedded');
 });
 
-it('empty entry set is ready with invariant held', () => {
-  const r = c.classifyCutover([]);
-  assert.strictEqual(r.blockers.length, 0);
-  assert.strictEqual(r.absent.length, 0);
+it('plan discloses scale and is CI-safe (content-ready + shape) on the current cwd', () => {
+  const p = c.plan(process.cwd(), { holds: [] });
+  assert.ok(typeof p.ready === 'boolean');
+  assert.ok(typeof p.fullyClean === 'boolean');
+  assert.ok(typeof p.modeDriftCount === 'number' && typeof p.originAheadCount === 'number');
+  assert.ok(Array.isArray(p.contentBlockers));
 });
 
-it('verifyClean holds-out documented holds (pure over an injected status is not needed; shape check)', () => {
-  // verifyClean runs git; here we assert its contract shape on the current (possibly clean) cwd.
-  const v = c.verifyClean(process.cwd(), { holds: [] });
-  assert.ok(typeof v.clean === 'boolean' && Array.isArray(v.dirty));
+it('divergence returns an array and never throws on the current cwd (temp-index, non-mutating)', () => {
+  const d = c.divergence(process.cwd(), []);
+  assert.ok(Array.isArray(d));
+  for (const e of d) assert.ok(typeof e.path === 'string' && typeof e.kind === 'string');
 });
 
 console.log(`baseline-cutover.spec: ${n} passed, 0 failed`);

--- a/scripts/baseline-cutover.spec.md
+++ b/scripts/baseline-cutover.spec.md
@@ -15,23 +15,33 @@ an instant blue-green rollback (working-tree bytes never change).
 ## API
 - `classifyCutover(entries) → {safe[], blockers[], holds[], absent[]}` — pure, unit-tested. `safe` =
   byte-identical to origin/main; `blocker` = diverges (uncaptured / undocumented); `hold` = documented
-  keep-dirty (e.g. L7 `governance-verify.js`); `absent` = not yet on origin/main.
-- `collectEntries(root, holds) → entries[]` — per drifted path, compares working bytes to
-  `origin/main:<path>` (best-effort; `[]` on clean/failure → CI-safe).
-- `plan(root, {holds}) → {ready, safeCount, blockers, holds, absent, invariantHeld}` — `ready` iff 0
-  blockers (holds allowed to remain).
+  keep-dirty (e.g. L7 `governance-verify.js`); `originAhead` = origin tracks it, working lacks it;
+  `untracked` = working-only residual (feat/3026 deliverable / new drift).
+- `divergence(root, holds) → entries[]` **(#3823, replaces content-only `collectEntries`)** — computes
+  the TRUE cutover delta the way `git reset --mixed origin/main` resolves, via a **temp index**
+  (`GIT_INDEX_FILE` + `read-tree origin/main`), then `git diff --raw --abbrev=40 -z` + a batched
+  `hash-object --stdin-paths`. Distinguishes **mode-only** (working blob == origin blob, exec-bit
+  differs) from real **content** divergence, and detects **origin-ahead** deletes. Never touches the
+  real index/HEAD/working tree.
+- `plan(root, {holds}) → {ready, fullyClean, safeCount, modeDriftCount, originAheadCount, untrackedCount,
+  contentBlockers, holds, willNormalizeModes, willRestoreFromOrigin, willLeaveUntracked}` — `ready` iff
+  0 **content** blockers; `fullyClean` iff nothing but holds remain. modeDrift/originAhead are
+  recipe-resolvable and REPORTED for honest scale disclosure.
 - `recipe(root, ref?) → {preconditions, reparkRecipe, rollbackRecipe}` — strings only; carries no
-  executable calls.
+  executable calls. Includes `checkout -- .` (mode-normalize + origin catch-up) and a moving-target freeze.
 - `verifyClean(root, {holds}) → {clean, dirty[], heldOut[]}` — post-cutover status check.
 - `selfTest()` — hard-gate assertions.
 
 ## Invariants
-1. **Byte-identity:** a path is `safe` only when its working bytes equal `origin/main`. Blockers are
-   reported, never clobbered.
-2. **Non-mutating / CI-safe:** dry-run/verify never change the tree; a clean checkout ⇒ `ready`, exit 0.
-3. **Reversible:** the emitted recipe preserves working bytes and includes an instant rollback (never
+1. **Truthful readiness (#3823):** the dry-run reflects the ACTUAL `reset --mixed` delta — mode-only
+   changes are counted as `modeDrift` (not content), and files origin has but the working tree lacks are
+   counted as `originAhead`. A content-only `cmp` gave a false "ready" (it missed 837 mode + 214
+   origin-ahead on the real checkout); this is the defect #3823 fixes.
+2. **Non-mutating / CI-safe:** dry-run/verify/divergence never change the repo (temp index in `os.tmpdir()`);
+   a clean checkout ⇒ ready + fullyClean, exit 0.
+3. **Reversible:** the emitted recipe preserves byte content and includes an instant rollback (never
    force-pushes main).
-4. Holds (documented keep-dirty) are never blockers.
+4. Holds (documented keep-dirty) are never content blockers.
 
 ## Enforced root
 `.github/workflows/baseline-cutover.yml` runs the spec (hard gate) + the dry-run (advisory), making

--- a/wiki/work-log/ticket-3823/manager-scope.md
+++ b/wiki/work-log/ticket-3823/manager-scope.md
@@ -1,0 +1,34 @@
+# #3823 — Manager Scope: baseline-cutover mode-awareness + origin-ahead truthfulness
+
+**Type:** bug/hardening · **Area:** governance/scripts · **Priority:** P1
+**Refs (bare):** fixes a defect in ticket-3822 exposed by the ticket-3801 AC4 cutover attempt;
+ticket-3818 closeout; design receipt 3355d17ac42b51ae.
+
+## Problem (found during the live cutover attempt)
+baseline-cutover.js reported ready=true on a CONTENT-ONLY byte-identity check (cmp), but the real
+`git reset --mixed origin/main` revealed 847 files MODIFIED (exec-bit only: canonical working tree is
+wholesale 100755, origin/main 100644) + 214 files "deleted" (origin/main tracks files the canonical
+working tree lacks — origin advanced past the canonical during the session). The tool's dry-run was
+NOT truthful: it missed mode drift and origin-ahead files, so "ready" was misleading.
+
+## Fix (truthful oracle; still non-mutating)
+Compute the cutover delta the way `reset --mixed origin/main` would, WITHOUT mutating the real repo:
+populate a TEMP index from origin/main (GIT_INDEX_FILE + read-tree), then `git diff --raw` (working
+tree vs temp index) + `ls-files --others`. Classify each path:
+- safe (content+mode identical), modeDrift (content same, mode differs -> recipe normalizes),
+  contentBlocker (content differs, not a documented hold/ancestor-safe), originAhead (origin tracks it,
+  working lacks it -> recipe restores), hold (documented), untracked (working-only residual).
+plan.ready becomes STRICT: true only when the recipe would yield a truly clean status
+(contentBlocker==0 && originAhead==0 && modeDrift resolvable). Recipe gains mode-normalization + origin
+catch-up steps. Never mutates the live checkout.
+
+## Acceptance criteria
+- [ ] AC1 pure classifier gains modeEqual + buckets modeDrift / originAhead; deterministic, unit-tested.
+- [ ] AC2 divergence() uses a temp index (no real-index/HEAD mutation); matches the reset --mixed oracle.
+- [ ] AC3 plan.ready strict (0 contentBlocker && 0 originAhead); modeDrift reported + recipe-normalized.
+- [ ] AC4 CI-safe (clean tree -> ready, exit 0); never mutates.
+- [ ] AC5 sibling spec + registry + CI green; enforcement-wiring-audit ENFORCED.
+- [ ] AC6 free >=2-family cross-model consensus; receipt recorded.
+
+## Rails
+Reversible/autonomous tooling fix. Still never executes the cutover. Does NOT Close ticket-3801/ticket-3818.

--- a/wiki/work-log/ticket-3823/validation.md
+++ b/wiki/work-log/ticket-3823/validation.md
@@ -1,0 +1,23 @@
+# #3823 — Validation (baseline-cutover mode-awareness)
+
+**Branch:** fix/3823-cutover-mode-aware · **Base:** origin/main
+**Files:** scripts/baseline-cutover.js (divergence oracle), .spec.js, .spec.md.
+
+## Result
+- node --check clean; spec 7/7; self-test PASS; governance-verify PASS; validator-discipline OK + AC7 self-test OK.
+- enforcement-wiring-audit 43/562 ENFORCED. Content-only changeset.
+- Cross-family consensus PASS -- receipt bfbd947c49504c05 (meta+mistral).
+
+## The defect fixed
+baseline-cutover (ticket-3822) reported ready=true on a CONTENT-ONLY cmp; the real reset --mixed showed
+837 mode-diffs + 214 origin-ahead it missed. New divergence() uses a TEMP INDEX (read-tree origin/main)
++ git diff --raw --abbrev=40 -z + batched hash-object to distinguish mode-only vs content vs origin-ahead.
+Two dev bugs fixed: raw reports working sha as 0000000 (hash-object the working copy instead); raw
+abbreviates origin sha (--abbrev=40 for full). Never mutates the live checkout (temp index in os.tmpdir).
+
+## Truthful dry-run vs REAL canonical (validates the fix)
+837 modeDrift (100755->100644) + 214 originAhead + 11 untracked + 9 content-divergences + 1 hold
+(governance-verify.js). Previously falsely "876 safe, ready".
+
+## AC status
+AC1 [x] AC2 [x] AC3 [x] AC4 [x] AC5 [x] AC6 [x] (bfbd947c49504c05)


### PR DESCRIPTION
Refs #3823. Fixes a truthfulness defect in baseline-cutover (#3822) exposed by the #3801 AC4 cutover attempt: it reported ready on a CONTENT-ONLY cmp, but the real reset --mixed showed 837 mode-diffs + 214 origin-ahead files it missed.

New divergence() computes the true cutover delta the way reset --mixed resolves — via a TEMP INDEX (read-tree origin/main) + git diff --raw --abbrev=40 -z + batched hash-object --stdin-paths — distinguishing mode-only vs content vs origin-ahead. Never mutates the live checkout (temp index in os.tmpdir). classifyCutover buckets safe/modeDrift/content/originAhead/untracked/hold; plan discloses scale; recipe adds mode-normalize + moving-target freeze.

Validated vs REAL canonical: now truthfully reports 837 modeDrift + 214 originAhead + 11 untracked + 9 content-divergences + 1 hold (was falsely '876 safe, ready').

Tests: node --check, spec 7/7, self-test PASS, governance-verify PASS, validator-discipline OK, enforcement-wiring 43/562 ENFORCED. Consensus PASS bfbd947c49504c05 (meta+mistral). Does NOT execute the cutover.